### PR TITLE
공통 텍스트필드 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.and03.ui.component
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.InputTransformation
@@ -24,7 +25,7 @@ fun EditableTextField(
     state: TextFieldState,
     onSearch: () -> Unit,
     modifier: Modifier = Modifier,
-    placeholderRes: Int = R.string.editable_text_field_hint,
+    @StringRes placeholderRes: Int = R.string.editable_text_field_hint,
     imeAction: ImeAction = ImeAction.Next,
     keyboardType: KeyboardType = KeyboardType.Text,
     maxCharacterCount: Int = 10,

--- a/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
@@ -1,0 +1,71 @@
+package com.boostcamp.and03.ui.component
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.maxLength
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.and03.R
+
+@Composable
+fun EditableTextField(
+    state: TextFieldState,
+    onSearch: (() -> Unit),
+    modifier: Modifier = Modifier,
+    placeholderRes: Int = R.string.editable_text_field_hint,
+    imeAction: ImeAction = ImeAction.Next,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    maxCharacterCount: Int = 10,
+    lineLimits: Int = 1,
+) {
+    OutlinedTextField(
+        state = state,
+        modifier = modifier,
+        placeholder = {
+            Text(text = stringResource(placeholderRes))
+        },
+        inputTransformation = InputTransformation.maxLength(maxCharacterCount),
+        keyboardOptions = KeyboardOptions(
+            autoCorrectEnabled = true,  // 키보드 자동 수정 기능
+            keyboardType = keyboardType,
+            imeAction = imeAction
+        ),
+        onKeyboardAction = {
+            onSearch()
+        },
+        lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = lineLimits),
+        shape = RoundedCornerShape(12.dp),
+        colors = TextFieldDefaults.colors(
+            focusedTextColor = MaterialTheme.colorScheme.onSurface,
+            unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+            focusedContainerColor = MaterialTheme.colorScheme.surface,
+            unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+            focusedIndicatorColor = MaterialTheme.colorScheme.outline,
+            unfocusedIndicatorColor = MaterialTheme.colorScheme.outline,
+            disabledIndicatorColor = MaterialTheme.colorScheme.outline,
+        ),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun EditableTextFieldPreview() {
+    EditableTextField(
+        state = TextFieldState(),
+        onSearch = {},
+        modifier = Modifier,
+    )
+
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
@@ -63,5 +63,4 @@ fun EditableTextFieldPreview() {
         onSearch = {},
         modifier = Modifier,
     )
-
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
@@ -22,7 +22,7 @@ import com.boostcamp.and03.R
 @Composable
 fun EditableTextField(
     state: TextFieldState,
-    onSearch: (() -> Unit),
+    onSearch: () -> Unit,
     modifier: Modifier = Modifier,
     placeholderRes: Int = R.string.editable_text_field_hint,
     imeAction: ImeAction = ImeAction.Next,
@@ -33,18 +33,14 @@ fun EditableTextField(
     OutlinedTextField(
         state = state,
         modifier = modifier,
-        placeholder = {
-            Text(text = stringResource(placeholderRes))
-        },
+        placeholder = { Text(text = stringResource(placeholderRes)) },
         inputTransformation = InputTransformation.maxLength(maxCharacterCount),
         keyboardOptions = KeyboardOptions(
             autoCorrectEnabled = true,  // 키보드 자동 수정 기능
             keyboardType = keyboardType,
             imeAction = imeAction
         ),
-        onKeyboardAction = {
-            onSearch()
-        },
+        onKeyboardAction = { onSearch() },
         lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = lineLimits),
         shape = RoundedCornerShape(12.dp),
         colors = TextFieldDefaults.colors(

--- a/app/src/main/java/com/boostcamp/and03/ui/component/LabelAndEditableTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/LabelAndEditableTextField.kt
@@ -1,0 +1,60 @@
+package com.boostcamp.and03.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.and03.R
+
+@Composable
+fun LabelAndEditableTextField(
+    labelRes: Int,
+    state: TextFieldState,
+    onSearch: () -> Unit,
+    modifier: Modifier = Modifier,
+    placeholderRes: Int = R.string.editable_text_field_hint,
+    imeAction: ImeAction = ImeAction.Next,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    maxCharacterCount: Int = 10,
+    lineLimits: Int = 1,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(labelRes),
+            style = MaterialTheme.typography.labelLarge,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        EditableTextField(
+            state = state,
+            onSearch = onSearch,
+            placeholderRes = placeholderRes,
+            imeAction = imeAction,
+            keyboardType = keyboardType,
+            maxCharacterCount = maxCharacterCount,
+            lineLimits = lineLimits,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun LabelAndTextFieldPreview() {
+    LabelAndEditableTextField(
+        labelRes = R.string.editable_text_field_hint,
+        state = TextFieldState(),
+        onSearch = {}
+    )
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/component/LabelAndEditableTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/LabelAndEditableTextField.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.and03.ui.component
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,7 +23,7 @@ fun LabelAndEditableTextField(
     state: TextFieldState,
     onSearch: () -> Unit,
     modifier: Modifier = Modifier,
-    placeholderRes: Int = R.string.editable_text_field_hint,
+    @StringRes placeholderRes: Int = R.string.editable_text_field_hint,
     imeAction: ImeAction = ImeAction.Next,
     keyboardType: KeyboardType = KeyboardType.Text,
     maxCharacterCount: Int = 10,

--- a/app/src/main/java/com/boostcamp/and03/ui/component/SearchTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/SearchTextField.kt
@@ -27,7 +27,7 @@ import com.boostcamp.and03.R
 @Composable
 fun SearchTextField(
     state: TextFieldState,
-    onSearch: (() -> Unit),
+    onSearch: () -> Unit,
     modifier: Modifier = Modifier,
     placeholderRes: Int = R.string.search_text_field_hint,
     enableCameraSearch: Boolean = false,
@@ -56,9 +56,7 @@ fun SearchTextField(
             keyboardType = KeyboardType.Text,
             imeAction = ImeAction.Search
         ),
-        onKeyboardAction = {
-            onSearch()
-        },
+        onKeyboardAction = { onSearch() },
         lineLimits = TextFieldLineLimits.SingleLine,
         shape = RoundedCornerShape(12.dp),
         colors = TextFieldDefaults.colors(

--- a/app/src/main/java/com/boostcamp/and03/ui/component/SearchTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/SearchTextField.kt
@@ -1,12 +1,11 @@
 package com.boostcamp.and03.ui.component
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
-import androidx.compose.foundation.text.input.maxLength
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -15,6 +14,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -29,7 +29,7 @@ fun SearchTextField(
     state: TextFieldState,
     onSearch: () -> Unit,
     modifier: Modifier = Modifier,
-    placeholderRes: Int = R.string.search_text_field_hint,
+    @StringRes placeholderRes: Int = R.string.search_text_field_hint,
     enableCameraSearch: Boolean = false,
     onCameraClick: (() -> Unit)? = null,
 ) {
@@ -66,9 +66,9 @@ fun SearchTextField(
             unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
             focusedLeadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
             unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            focusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
-            unfocusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
-            disabledIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
         ),
     )
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/prototype/screen/CanvasScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/prototype/screen/CanvasScreen.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.and03.ui.screen.prototype.screen
 
-import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -43,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.boostcamp.and03.R
+import com.boostcamp.and03.ui.component.EditableTextField
 import com.boostcamp.and03.ui.component.SearchTextField
 import com.boostcamp.and03.ui.screen.prototype.model.Edge
 import com.boostcamp.and03.ui.screen.prototype.model.MemoNode
@@ -66,47 +65,54 @@ fun CanvasScreen(
 
     Scaffold(
         floatingActionButton = {
-            ExtendedFloatingActionButton(onClick = {
-                navController.navigate(PrototypeRoute.MemoEdit)
-            }, icon = {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_edit_outlined),
-                    contentDescription = null
-                )
-            }, text = {
-                Text(text = "메모 작성")
-            })
-        }) { padding ->
+            ExtendedFloatingActionButton(
+                onClick = {
+                    navController.navigate(PrototypeRoute.MemoEdit)
+                }, icon = {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_edit_outlined),
+                        contentDescription = null
+                    )
+                }, text = {
+                    Text(text = "메모 작성")
+                })
+        }
+    ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
         ) {
-            Button(onClick = {
-                connectMode = !connectMode
-                selectedIds = emptyList()
-            }) {
+            Button(
+                onClick = {
+                    connectMode = !connectMode
+                    selectedIds = emptyList()
+                }
+            ) {
                 Text(if (connectMode) "연결 취소" else "연결하기")
             }
 
-            Button(onClick = {
-                viewModel.snapToGrid(300f)
-            }) {
+            Button(
+                onClick = {
+                    viewModel.snapToGrid(300f)
+                }
+            ) {
                 Text("격자 정렬")
             }
 
-            Box(modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer {
-                    scaleX = scale
-                    scaleY = scale
-                }
-                .pointerInput(Unit) {
-                    detectTransformGestures { _, pan, zoom, _ ->
-                        scale = (scale * zoom).coerceIn(minScale, maxScale)
-                        panOffset += pan
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
                     }
-                }) {
+                    .pointerInput(Unit) {
+                        detectTransformGestures { _, pan, zoom, _ ->
+                            scale = (scale * zoom).coerceIn(minScale, maxScale)
+                            panOffset += pan
+                        }
+                    }) {
                 ArrowCanvas(
                     arrows = items.edges,
                     items = items.nodes,
@@ -159,23 +165,23 @@ fun DraggableItem(
     Box(
         modifier = Modifier
             // offset으로 이동, 캔버스 오프셋이랑 아이템 오프셋을 같이 적용
-        .graphicsLayer {
-            translationX = item.offset.x + panOffset.x
-            translationY = item.offset.y + panOffset.y
-        }
-            // 아이템 이동하면서 선도 같이 움직이도록
-        .onGloballyPositioned { coords ->
-            onSizeChanged(coords.size)
-        }
-            // 클릭
-        .combinedClickable(onClick = onClick)
-            // 드래그 제스처
-        .pointerInput(item.id) {
-            detectDragGestures { change, dragAmount ->
-                change.consume()
-                onMove(dragAmount)
+            .graphicsLayer {
+                translationX = item.offset.x + panOffset.x
+                translationY = item.offset.y + panOffset.y
             }
-        }
+            // 아이템 이동하면서 선도 같이 움직이도록
+            .onGloballyPositioned { coords ->
+                onSizeChanged(coords.size)
+            }
+            // 클릭
+            .combinedClickable(onClick = onClick)
+            // 드래그 제스처
+            .pointerInput(item.id) {
+                detectDragGestures { change, dragAmount ->
+                    change.consume()
+                    onMove(dragAmount)
+                }
+            }
             .background(
                 if (isSelected) Color(0xFFBBDEFB) else Color.White, RoundedCornerShape(8.dp)
             )

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/prototype/screen/CanvasScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/prototype/screen/CanvasScreen.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.EditableTextField
+import com.boostcamp.and03.ui.component.LabelAndEditableTextField
 import com.boostcamp.and03.ui.component.SearchTextField
 import com.boostcamp.and03.ui.screen.prototype.model.Edge
 import com.boostcamp.and03.ui.screen.prototype.model.MemoNode
@@ -66,16 +67,16 @@ fun CanvasScreen(
     Scaffold(
         floatingActionButton = {
             ExtendedFloatingActionButton(
-                onClick = {
-                    navController.navigate(PrototypeRoute.MemoEdit)
-                }, icon = {
+                onClick = { navController.navigate(PrototypeRoute.MemoEdit) },
+                icon = {
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_edit_outlined),
                         contentDescription = null
                     )
                 }, text = {
                     Text(text = "메모 작성")
-                })
+                }
+            )
         }
     ) { padding ->
         Column(
@@ -112,7 +113,8 @@ fun CanvasScreen(
                             scale = (scale * zoom).coerceIn(minScale, maxScale)
                             panOffset += pan
                         }
-                    }) {
+                    }
+            ) {
                 ArrowCanvas(
                     arrows = items.edges,
                     items = items.nodes,
@@ -127,7 +129,6 @@ fun CanvasScreen(
                         isSelected = selectedIds.contains(item.id),
                         onClick = {
                             if (connectMode) {
-
                                 selectedIds =
                                     if (selectedIds.contains(item.id)) selectedIds - item.id
                                     else (selectedIds + item.id).takeLast(2)
@@ -146,7 +147,8 @@ fun CanvasScreen(
                         },
                         onSizeChanged = { size ->
                             nodeSizes = nodeSizes + (item.id to size)
-                        })
+                        }
+                    )
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <!--  component  -->
     <string name="search_text_field_hint">검색어를 입력하세요.</string>
+    <string name="editable_text_field_hint">책 제목을 입력하세요.</string>
 
     <!-- 바텀 탭 문자열 -->
     <string name="bottom_tab_booklist">책 목록</string>


### PR DESCRIPTION
## #️⃣연관된 이슈
- #36 
- #38 

## 📝작업 내용

### 텍스트필드 컴포넌트
- [x] 공용 입력 컴포넌트 EditableTextField 구현
- [x] TextFieldState 기반 입력 상태 관리 적용
- [x] 최대 입력 글자 수 제한 기능 추가 (maxCharacterCount)
- [x] IME Action 파라미터화 (Next 기본값) 및 키보드 액션 콜백 (onSearch) 연결
- [x] 키보드 타입 (KeyboardType) 커스터마이징 가능하도록 설계
- [x] 단일/다중 라인 입력을 지원하도록 lineLimits 파라미터 제공
- [x] InputTransformation.maxLength를 활용한 입력 단계 제한 처리
- [x] OutlinedTextField 기반 UI 구성 및 Rounded Corner 스타일 적용
- [x] Material3 테마 색상을 사용하여 텍스트 / 컨테이너 / 인디케이터 색상 통일
- [x] placeholder 문자열 리소스화 (@StringRes)로 다국어 대응

### 라벨이 붙은 텍스트필드 컴포넌트
- [x] 텍스트필드 상단에 라벨을 포함한 LabelAndEditableTextField 공용 컴포넌트 구현
- [x] 기존 EditableTextField를 재사용한 조합형 컴포넌트 구조로 설계
- [x] 라벨 텍스트를 @StringRes 기반으로 처리하여 다국어 대응
- [x] 라벨과 입력 필드 간 간격을 Spacer로 분리하여 레이아웃 명확화
- [x] IME Action, KeyboardType, 최대 입력 글자 수(maxCharacterCount) 파라미터 위임
- [x] 단일/다중 라인 입력을 지원하도록 lineLimits 파라미터 제공
- [x] Material3 Typography(labelLarge)를 활용한 라벨 스타일 적용
- [x] 입력 필드에 Modifier.fillMaxWidth() 적용하여 레이아웃 일관성 확보
- [x] Preview 추가를 통해 컴포넌트 단독 UI 확인 가능하도록 구성

## 🖼️스크린샷


https://github.com/user-attachments/assets/0e719b4f-3239-4147-a5c2-513d6bf13728

<img width="500" alt="image" src="https://github.com/user-attachments/assets/239858da-8b59-47f0-81ad-d388831300fe" />




