### PR TITLE
테마가 자동으로 지정되지 않는 현상 수정

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/ui/theme/Color.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/theme/Color.kt
@@ -110,7 +110,7 @@ data class And03Colors(
     val scrim: Color
 )
 
-internal val lightAnd03Colors = And03Colors(
+internal val lightMainColors = And03Colors(
     primary = Primary,
     onPrimary = OnPrimary,
 
@@ -173,5 +173,5 @@ internal val darkMainColors = And03Colors(
 )
 
 internal val LocalAnd03Colors = staticCompositionLocalOf {
-    lightAnd03Colors
+    lightMainColors
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/theme/Theme.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/theme/Theme.kt
@@ -11,32 +11,32 @@ fun And03Theme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val mainColors = if(darkTheme) darkMainColors else lightMainColors
+    val and03Colors = if(darkTheme) darkMainColors else lightMainColors
 
     val mainColorScheme = lightColorScheme(
-        primary = mainColors.primary,
-        onPrimary = mainColors.onPrimary,
-        primaryContainer = mainColors.primaryContainer,
-        onPrimaryContainer = mainColors.onPrimaryContainer,
-        secondary = mainColors.secondary,
-        onSecondary = mainColors.onSecondary,
-        secondaryContainer = mainColors.secondaryContainer,
-        onSecondaryContainer = mainColors.onSecondaryContainer,
-        background = mainColors.background,
-        onBackground = mainColors.onBackground,
-        surface = mainColors.surface,
-        onSurface = mainColors.onSurface,
-        surfaceVariant = mainColors.surfaceVariant,
-        onSurfaceVariant = mainColors.onSurfaceVariant,
-        error = mainColors.error,
-        onError = mainColors.onError,
-        outline = mainColors.outline,
-        outlineVariant = mainColors.outlineVariant,
-        scrim = mainColors.scrim
+        primary = and03Colors.primary,
+        onPrimary = and03Colors.onPrimary,
+        primaryContainer = and03Colors.primaryContainer,
+        onPrimaryContainer = and03Colors.onPrimaryContainer,
+        secondary = and03Colors.secondary,
+        onSecondary = and03Colors.onSecondary,
+        secondaryContainer = and03Colors.secondaryContainer,
+        onSecondaryContainer = and03Colors.onSecondaryContainer,
+        background = and03Colors.background,
+        onBackground = and03Colors.onBackground,
+        surface = and03Colors.surface,
+        onSurface = and03Colors.onSurface,
+        surfaceVariant = and03Colors.surfaceVariant,
+        onSurfaceVariant = and03Colors.onSurfaceVariant,
+        error = and03Colors.error,
+        onError = and03Colors.onError,
+        outline = and03Colors.outline,
+        outlineVariant = and03Colors.outlineVariant,
+        scrim = and03Colors.scrim
     )
 
     CompositionLocalProvider(
-        LocalAnd03Colors provides mainColors,
+        LocalAnd03Colors provides and03Colors,
         LocalAnd03Typography provides and03Typography,
         LocalAnd03Shapes provides and03Shapes
     ) {

--- a/app/src/main/java/com/boostcamp/and03/ui/theme/Theme.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/theme/Theme.kt
@@ -2,27 +2,46 @@ package com.boostcamp.and03.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-
-private val LightAnd03Scheme = lightAnd03Colors
-private val DarkAnd03Scheme = darkMainColors
 
 @Composable
 fun And03Theme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val mainColorScheme = if(darkTheme) DarkAnd03Scheme else LightAnd03Scheme
+    val mainColors = if(darkTheme) darkMainColors else lightMainColors
+
+    val mainColorScheme = lightColorScheme(
+        primary = mainColors.primary,
+        onPrimary = mainColors.onPrimary,
+        primaryContainer = mainColors.primaryContainer,
+        onPrimaryContainer = mainColors.onPrimaryContainer,
+        secondary = mainColors.secondary,
+        onSecondary = mainColors.onSecondary,
+        secondaryContainer = mainColors.secondaryContainer,
+        onSecondaryContainer = mainColors.onSecondaryContainer,
+        background = mainColors.background,
+        onBackground = mainColors.onBackground,
+        surface = mainColors.surface,
+        onSurface = mainColors.onSurface,
+        surfaceVariant = mainColors.surfaceVariant,
+        onSurfaceVariant = mainColors.onSurfaceVariant,
+        error = mainColors.error,
+        onError = mainColors.onError,
+        outline = mainColors.outline,
+        outlineVariant = mainColors.outlineVariant,
+        scrim = mainColors.scrim
+    )
 
     CompositionLocalProvider(
-        LocalAnd03Colors provides mainColorScheme,
+        LocalAnd03Colors provides mainColors,
         LocalAnd03Typography provides and03Typography,
         LocalAnd03Shapes provides and03Shapes
     ) {
         MaterialTheme(
-            colorScheme = colorScheme,
+            colorScheme = mainColorScheme,
             typography = Typography,
             content = content
         )


### PR DESCRIPTION
## #️⃣연관된 이슈
- #41

## 📝작업 내용
- [x] ColorScheme 타입의 커스텀 테마 Scheme 생성하기
- [x] MaterialTheme에 MaterialTheme.colorScheme 대신 커스텀 테마 Scheme 주입하기

## 🤔시행착오
- 아래의 코드에서 볼 수 있듯 MaterialTheme에 커스텀 테마 스키마 대신 MaterialTheme.colorScheme가 주입되고 있었습니다.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/085a1d26-4052-495b-9c8f-d34039f1bd04" />
<br>

- 해결을 위해 이미 선언했던 mainColorScheme를 주입하려 했으나
`ColorScheme` 타입이 아닌 `And03Colors` 타입이라 주입할 수 없었습니다.
- 그래서 새로 `mainColorScheme`를 만들고, colors 타입임에도 scheme로 명명된 변수들의 이름을 수정했습니다.

## 🖼️스크린샷

- 아래와 같이 자동으로 커스텀 테마 색상이 지정되는 것을 확인하실 수 있습니다.

<img width="1271" height="1375" alt="image" src="https://github.com/user-attachments/assets/7ab362c6-71bf-4014-934c-4d992e01f4d9" />
