### PR TITLE
책 검색 화면 UI, 검색 결과 출력 및 아이템 선택 동작 구현

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/And03Application.kt
+++ b/app/src/main/java/com/boostcamp/and03/And03Application.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.and03
 
-
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 

--- a/app/src/main/java/com/boostcamp/and03/data/di/BookRepositoryModule.kt
+++ b/app/src/main/java/com/boostcamp/and03/data/di/BookRepositoryModule.kt
@@ -1,0 +1,20 @@
+package com.boostcamp.and03.data.di
+
+import com.boostcamp.and03.data.repository.book.BookRepository
+import com.boostcamp.and03.data.repository.book.BookRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class BookRepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindBookRepository(
+        impl: BookRepositoryImpl
+    ): BookRepository
+}

--- a/app/src/main/java/com/boostcamp/and03/data/model/response/NaverBookItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/data/model/response/NaverBookItem.kt
@@ -1,12 +1,13 @@
 package com.boostcamp.and03.data.model.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class NaverBookItem(
-    val title: String,
-    val image: String,
-    val author: String,
-    val publisher: String,
-    val isbn: String
+    @SerialName("title") val title: String,
+    @SerialName("image ") val thumbnail: String,
+    @SerialName("author") val author: String,
+    @SerialName("publisher") val publisher: String,
+    @SerialName("isbn") val isbn: String
 )

--- a/app/src/main/java/com/boostcamp/and03/data/model/response/NaverBookItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/data/model/response/NaverBookItem.kt
@@ -8,4 +8,5 @@ data class NaverBookItem(
     val image: String,
     val author: String,
     val publisher: String,
+    val isbn: String
 )

--- a/app/src/main/java/com/boostcamp/and03/data/model/response/NaverBookItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/data/model/response/NaverBookItem.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class NaverBookItem(
     @SerialName("title") val title: String,
-    @SerialName("image ") val thumbnail: String,
+    @SerialName("image") val thumbnail: String,
     @SerialName("author") val author: String,
     @SerialName("publisher") val publisher: String,
     @SerialName("isbn") val isbn: String

--- a/app/src/main/java/com/boostcamp/and03/data/repository/book/NaverBookItemMapper.kt
+++ b/app/src/main/java/com/boostcamp/and03/data/repository/book/NaverBookItemMapper.kt
@@ -2,12 +2,11 @@ package com.boostcamp.and03.data.repository.book
 
 import com.boostcamp.and03.data.model.response.NaverBookItem
 import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
+import kotlinx.collections.immutable.toImmutableList
 
 fun NaverBookItem.toUiModel() = BookUIModel(
     title = title,
-    author = author
-        .split("^")
-        .joinToString(", ") { it.trim() },
+    authors = author.split("^").toImmutableList(),
     publisher = publisher,
     thumbnail = thumbnail,
     isbn = isbn

--- a/app/src/main/java/com/boostcamp/and03/data/repository/book/NaverBookItemMapper.kt
+++ b/app/src/main/java/com/boostcamp/and03/data/repository/book/NaverBookItemMapper.kt
@@ -1,0 +1,14 @@
+package com.boostcamp.and03.data.repository.book
+
+import com.boostcamp.and03.data.model.response.NaverBookItem
+import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
+
+fun NaverBookItem.toUiModel() = BookUIModel(
+    title = title,
+    author = author
+        .split("^")
+        .joinToString(", ") { it.trim() },
+    publisher = publisher,
+    thumbnail = thumbnail,
+    isbn = isbn
+)

--- a/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
@@ -65,6 +65,7 @@ fun SearchResultItem(
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(Dimensions.PADDING_M),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(

--- a/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
@@ -23,6 +23,8 @@ import coil.compose.AsyncImage
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 private object SearchResultItemValues {
     val borderWidth = 2.dp
@@ -36,7 +38,7 @@ private object SearchResultItemValues {
 fun SearchResultItem(
     thumbnail: String,
     title: String,
-    author: String,
+    authors: ImmutableList<String>,
     publisher: String,
     isSelected: Boolean,
     modifier: Modifier = Modifier,
@@ -91,7 +93,7 @@ fun SearchResultItem(
                 )
 
                 Text(
-                    text = author,
+                    text = authors.joinToString(", "),
                     style = And03Theme.typography.bodyMedium,
                     color = And03Theme.colors.onSurfaceVariant,
                     maxLines = SearchResultItemValues.AUTHOR_PUBLISHER_MAX_LINES,
@@ -120,7 +122,7 @@ private fun SearchResultItemPreview() {
         SearchResultItem(
             thumbnail = "",
             title = "책 제목",
-            author = "책 저자",
+            authors = persistentListOf("김김김", "앤앤앤", "장장장"),
             publisher = "책 출판사",
             isSelected = false,
             onClick = {}
@@ -131,7 +133,7 @@ private fun SearchResultItemPreview() {
             title = """
                 선택된 책 제목. 테두리 색이 바뀌었습니다. 그런데 여기서 개행을 해야 한다면...........????????????
             """.trimIndent(),
-            author = "선택된 책 저자",
+            authors = persistentListOf("패트", "매트"),
             publisher = "선택된 책 출판사",
             isSelected = true,
             onClick = {}

--- a/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
@@ -66,7 +66,7 @@ fun SearchResultItem(
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(Dimensions.PADDING_M),
+            horizontalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_M),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(

--- a/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
@@ -68,8 +68,8 @@ fun SearchResultItem(
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_M),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_M)
         ) {
             AsyncImage(
                 model = thumbnail,
@@ -80,9 +80,7 @@ fun SearchResultItem(
             )
 
             Column(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .padding(start = And03Padding.PADDING_M),
+                modifier = Modifier.fillMaxHeight(),
                 verticalArrangement = Arrangement.SpaceEvenly
             ) {
                 Text(

--- a/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/SearchResultItem.kt
@@ -35,7 +35,7 @@ private object SearchResultItemValues {
 fun SearchResultItem(
     thumbnail: String,
     title: String,
-    authors: String,
+    author: String,
     publisher: String,
     isSelected: Boolean,
     modifier: Modifier = Modifier,
@@ -87,7 +87,7 @@ fun SearchResultItem(
                 )
 
                 Text(
-                    text = authors,
+                    text = author,
                     style = And03Theme.typography.bodyMedium,
                     color = And03Theme.colors.onSurfaceVariant,
                     maxLines = SearchResultItemValues.TITLE_MAX_LINES,
@@ -116,7 +116,7 @@ private fun SearchResultItemPreview() {
         SearchResultItem(
             thumbnail = "",
             title = "책 제목",
-            authors = "책 저자",
+            author = "책 저자",
             publisher = "책 출판사",
             isSelected = false,
             onClick = {}
@@ -127,7 +127,7 @@ private fun SearchResultItemPreview() {
             title = """
                 선택된 책 제목. 테두리 색이 바뀌었습니다. 그런데 여기서 개행을 해야 한다면...........????????????
             """.trimIndent(),
-            authors = "선택된 책 저자",
+            author = "선택된 책 저자",
             publisher = "선택된 책 출판사",
             isSelected = true,
             onClick = {}

--- a/app/src/main/java/com/boostcamp/and03/ui/component/SearchTopBar.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/SearchTopBar.kt
@@ -21,7 +21,8 @@ fun SearchTopBar(
     title: String,
     onBackClick: () -> Unit,
     onSaveClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isSaveEnabled: Boolean = false
 ) {
     CenterAlignedTopAppBar(
         title = { Text(text = title) },
@@ -37,7 +38,8 @@ fun SearchTopBar(
         },
         actions = {
             IconButton(
-                onClick = onSaveClick
+                onClick = onSaveClick,
+                enabled = isSaveEnabled
             ) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_check_filled),

--- a/app/src/main/java/com/boostcamp/and03/ui/component/SearchTopBar.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/SearchTopBar.kt
@@ -1,0 +1,61 @@
+package com.boostcamp.and03.ui.component
+
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.boostcamp.and03.R
+import com.boostcamp.and03.ui.theme.And03Theme
+
+// 임시로 사용할 탑 바
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchTopBar(
+    title: String,
+    onBackClick: () -> Unit,
+    onSaveClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    CenterAlignedTopAppBar(
+        title = { Text(text = title) },
+        navigationIcon = {
+            IconButton(
+                onClick = onBackClick
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_keyboard_arrow_left_filled),
+                    contentDescription = stringResource(R.string.content_description_go_back)
+                )
+            }
+        },
+        actions = {
+            IconButton(
+                onClick = onSaveClick
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_check_filled),
+                    contentDescription = stringResource(R.string.content_description_save_button)
+                )
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+private fun SearchTopBarPreview() {
+    And03Theme {
+        SearchTopBar(
+            title = "책 검색",
+            onBackClick = {},
+            onSaveClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavHost.kt
@@ -28,7 +28,7 @@ fun MainNavHost(
         )
 
         bookSearchNavGraph(
-            navController = navigator.navController,
+            navigator = navigator,
             modifier = modifier.padding(paddingValues)
         )
 

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavHost.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import com.boostcamp.and03.ui.screen.addbook.addBookNavGraph
 import com.boostcamp.and03.ui.screen.booklist.booklistNavGraph
+import com.boostcamp.and03.ui.screen.booksearch.bookSearchNavGraph
 import com.boostcamp.and03.ui.screen.mypage.myPageNavGraph
 
 @Composable
@@ -20,6 +21,11 @@ fun MainNavHost(
         startDestination = navigator.startDestination
     ) {
         booklistNavGraph(modifier = modifier.padding(paddingValues))
+
+        bookSearchNavGraph(
+            navController = navigator.navController,
+            modifier = modifier.padding(paddingValues)
+        )
 
         addBookNavGraph(modifier = modifier.padding(paddingValues))
 

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavigator.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavigator.kt
@@ -68,7 +68,6 @@ class MainNavigator(
     }
 
     fun navigatePopBackStack() = navController.popBackStack()
-
 }
 
 @SuppressLint("ComposableNaming")

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/Route.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/Route.kt
@@ -7,6 +7,9 @@ sealed interface Route {
     data object Booklist : Route
 
     @Serializable
+    data object BookSearch : Route
+
+    @Serializable
     data object AddBook : Route
 
     @Serializable

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/model/BookUIModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/model/BookUIModel.kt
@@ -1,11 +1,12 @@
 package com.boostcamp.and03.ui.screen.booklist.model
 
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class BookUIModel(
     val title: String,
-    val author: String,
+    val authors: ImmutableList<String>,
     val publisher: String,
     val thumbnail: String,
     val isbn: String // 국제표준도서번호, 고유 id로 활용

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/model/BookUIModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/model/BookUIModel.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.and03.ui.screen.booklist.model
 
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/model/BookUIModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/model/BookUIModel.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class BookUIModel(
     val title: String,
-    val authors: ImmutableList<String>,
+    val author: String,
     val publisher: String,
     val thumbnail: String,
     val isbn: String // 국제표준도서번호, 고유 id로 활용

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchNavGraph.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchNavGraph.kt
@@ -4,15 +4,16 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.boostcamp.and03.ui.navigation.MainNavigator
 import com.boostcamp.and03.ui.navigation.Route
 
 fun NavGraphBuilder.bookSearchNavGraph(
-    navController: NavController,
+    navigator: MainNavigator,
     modifier: Modifier = Modifier
 ) {
     composable<Route.BookSearch> {
         BookSearchRoute(
-            onBackClick = { navController.popBackStack() }
+            onBackClick = navigator::navigatePopBackStack
         )
     }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchNavGraph.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchNavGraph.kt
@@ -1,0 +1,18 @@
+package com.boostcamp.and03.ui.screen.booksearch
+
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.boostcamp.and03.ui.navigation.Route
+
+fun NavGraphBuilder.bookSearchNavGraph(
+    navController: NavController,
+    modifier: Modifier = Modifier
+) {
+    composable<Route.BookSearch> {
+        BookSearchRoute(
+            onBackClick = { navController.popBackStack() }
+        )
+    }
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
@@ -25,6 +26,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemKey
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03Button
 import com.boostcamp.and03.ui.component.SearchResultItem
@@ -110,12 +112,9 @@ private fun BookSearchScreen(
                 ) {
                     items(
                         count = searchResults.itemCount,
-                        key = { index ->
-                            searchResults[index]?.isbn ?: index
-                        }
+                        key = searchResults.itemKey { it.isbn }
                     ) { index ->
                         val book = searchResults[index] ?: return@items
-
                         SearchResultItem(
                             thumbnail = book.thumbnail,
                             title = book.title,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -1,20 +1,39 @@
 package com.boostcamp.and03.ui.screen.booksearch
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
 
 @Composable
 fun BookSearchRoute(
+    onBackClick: () -> Unit,
     viewModel: BookSearchViewModel = hiltViewModel(),
-    onItemClick: (BookUIModel) -> Unit
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val searchResults = viewModel.pagingBooksFlow.collectAsLazyPagingItems()
 
+    BookSearchScreen(
+        uiState = uiState,
+        searchResults = searchResults,
+        onQueryChange = viewModel::changeQuery,
+        onItemClick = viewModel::clickItem,
+        onSaveClick = { /* TODO: viewModel::saveItem 구현 */ },
+        onManualAddClick = { /* TODO: 책 추가 화면 구현 및 이동 동작 구현 */ }
+    )
 }
 
 @Composable
 private fun BookSearchScreen(
-
+    uiState: BookSearchUiState,
+    searchResults: LazyPagingItems<BookUIModel>,
+    onQueryChange: (String) -> Unit,
+    onItemClick: (BookUIModel) -> Unit,
+    onSaveClick: (BookUIModel) -> Unit,
+    onManualAddClick: () -> Unit,
 ) {
 
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -1,0 +1,20 @@
+package com.boostcamp.and03.ui.screen.booksearch
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
+
+@Composable
+fun BookSearchRoute(
+    viewModel: BookSearchViewModel = hiltViewModel(),
+    onItemClick: (BookUIModel) -> Unit
+) {
+
+}
+
+@Composable
+private fun BookSearchScreen(
+
+) {
+
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -35,6 +35,7 @@ import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.flowOf
 
 @Composable
@@ -121,7 +122,7 @@ private fun BookSearchScreen(
                         SearchResultItem(
                             thumbnail = book.thumbnail,
                             title = book.title,
-                            author = book.author,
+                            authors = book.authors,
                             publisher = book.publisher,
                             isSelected = book.isbn == uiState.selectedBookISBN,
                             onClick = { onItemClick(book) }
@@ -171,14 +172,14 @@ private fun BookSearchScreenPreview() {
         BookUIModel(
             isbn = "111",
             title = "이펙티브 코틀린",
-            author = "마르친 모스칼라",
+            authors = persistentListOf("마르친 모스칼라"),
             publisher = "인사이트",
             thumbnail = ""
         ),
         BookUIModel(
             isbn = "222",
             title = "안드로이드 Compose 완벽 가이드",
-            author = "Compose 팀",
+            authors = persistentListOf("Compose 팀"),
             publisher = "구글",
             thumbnail = ""
         )

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -192,3 +192,28 @@ private fun BookSearchScreenPreview() {
         )
     }
 }
+
+@Preview(showBackground = true)
+@Composable
+private fun BookSearchScreenEmptyBeforeQueryPreview() {
+    val uiState = BookSearchUiState(
+        query = "",
+        selectedBookISBN = null
+    )
+
+    val pagingItems = flowOf(
+        PagingData.empty<BookUIModel>()
+    ).collectAsLazyPagingItems()
+
+    And03Theme {
+        BookSearchScreen(
+            uiState = uiState,
+            searchResults = pagingItems,
+            onQueryChange = {},
+            onBackClick = {},
+            onItemClick = {},
+            onSaveClick = {},
+            onManualAddClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -10,8 +10,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -63,7 +65,11 @@ private fun BookSearchScreen(
     onManualAddClick: () -> Unit,
     modifier: Modifier= Modifier
 ) {
-    val searchTextState = remember { TextFieldState() }
+    val searchTextState = rememberTextFieldState(uiState.query)
+
+    LaunchedEffect(searchTextState.text) {
+        onQueryChange(searchTextState.text.toString())
+    }
 
     Column(modifier = modifier.fillMaxSize()) {
         SearchTopBar(

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -66,7 +66,7 @@ private fun BookSearchScreen(
     onItemClick: (BookUIModel) -> Unit,
     onSaveClick: () -> Unit,
     onManualAddClick: () -> Unit,
-    modifier: Modifier= Modifier
+    modifier: Modifier = Modifier
 ) {
     val searchTextState = remember { TextFieldState(uiState.query) }
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -99,7 +99,7 @@ private fun BookSearchScreen(
             else -> {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(Dimensions.PADDING_L),
+                    contentPadding = PaddingValues(horizontal = Dimensions.PADDING_L),
                     verticalArrangement = Arrangement.spacedBy(Dimensions.PADDING_M)
                 ) {
                     items(

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -1,12 +1,33 @@
 package com.boostcamp.and03.ui.screen.booksearch
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.boostcamp.and03.R
+import com.boostcamp.and03.ui.component.And03Button
+import com.boostcamp.and03.ui.component.SearchResultItem
+import com.boostcamp.and03.ui.component.SearchTextField
+import com.boostcamp.and03.ui.component.SearchTopBar
 import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
+import com.boostcamp.and03.ui.theme.And03Theme
+import com.boostcamp.and03.ui.theme.Dimensions
 
 @Composable
 fun BookSearchRoute(
@@ -20,6 +41,7 @@ fun BookSearchRoute(
         uiState = uiState,
         searchResults = searchResults,
         onQueryChange = viewModel::changeQuery,
+        onBackClick = onBackClick,
         onItemClick = viewModel::clickItem,
         onSaveClick = { /* TODO: viewModel::saveItem 구현 */ },
         onManualAddClick = { /* TODO: 책 추가 화면 구현 및 이동 동작 구현 */ }
@@ -31,9 +53,93 @@ private fun BookSearchScreen(
     uiState: BookSearchUiState,
     searchResults: LazyPagingItems<BookUIModel>,
     onQueryChange: (String) -> Unit,
+    onBackClick: () -> Unit,
     onItemClick: (BookUIModel) -> Unit,
-    onSaveClick: (BookUIModel) -> Unit,
+    onSaveClick: () -> Unit,
     onManualAddClick: () -> Unit,
+    modifier: Modifier= Modifier
 ) {
+    val searchTextState = remember { TextFieldState() }
 
+    Column(modifier = modifier.fillMaxSize()) {
+        SearchTopBar(
+            title = stringResource(R.string.book_search_title),
+            onBackClick = onBackClick,
+            onSaveClick = onSaveClick,
+            isSaveEnabled = uiState.isSaveEnabled
+        )
+
+        SearchTextField(
+            state = searchTextState,
+            onSearch = { onQueryChange(searchTextState.text.toString()) }
+        )
+
+        when {
+            uiState.query.isBlank() -> {
+                BookSearchEmptySection(
+                    message = stringResource(R.string.book_search_empty_before_query),
+                    onManualAddClick = onManualAddClick
+                )
+            }
+
+            searchResults.itemCount == 0 -> {
+                BookSearchEmptySection(
+                    message = stringResource(R.string.book_search_empty_after_query),
+                    onManualAddClick = onManualAddClick
+                )
+            }
+
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(Dimensions.PADDING_L),
+                    verticalArrangement = Arrangement.spacedBy(Dimensions.PADDING_M)
+                ) {
+                    items(
+                        count = searchResults.itemCount,
+                        key = { index ->
+                            searchResults[index]?.isbn ?: index
+                        }
+                    ) { index ->
+                        val book = searchResults[index] ?: return@items
+
+                        SearchResultItem(
+                            thumbnail = book.thumbnail,
+                            title = book.title,
+                            author = book.author,
+                            publisher = book.publisher,
+                            isSelected = book.isbn == uiState.selectedBookISBN,
+                            onClick = { onItemClick(book) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BookSearchEmptySection(
+    message: String,
+    onManualAddClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = message,
+            style = And03Theme.typography.bodyLarge,
+            color = And03Theme.colors.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(Dimensions.PADDING_L))
+
+        And03Button(
+            text = stringResource(R.string.book_search_button_text),
+            onClick = onManualAddClick
+        )
+    }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -5,19 +5,22 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.boostcamp.and03.R
@@ -28,6 +31,7 @@ import com.boostcamp.and03.ui.component.SearchTopBar
 import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
 import com.boostcamp.and03.ui.theme.And03Theme
 import com.boostcamp.and03.ui.theme.Dimensions
+import kotlinx.coroutines.flow.flowOf
 
 @Composable
 fun BookSearchRoute(
@@ -71,7 +75,10 @@ private fun BookSearchScreen(
 
         SearchTextField(
             state = searchTextState,
-            onSearch = { onQueryChange(searchTextState.text.toString()) }
+            onSearch = { onQueryChange(searchTextState.text.toString()) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Dimensions.PADDING_M)
         )
 
         when {
@@ -140,6 +147,48 @@ private fun BookSearchEmptySection(
         And03Button(
             text = stringResource(R.string.book_search_button_text),
             onClick = onManualAddClick
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BookSearchScreenPreview() {
+    val uiState = BookSearchUiState(
+        query = "안드로이드",
+        selectedBookISBN = "222"
+    )
+
+    val previewBooks = listOf(
+        BookUIModel(
+            isbn = "111",
+            title = "이펙티브 코틀린",
+            author = "마르친 모스칼라",
+            publisher = "인사이트",
+            thumbnail = ""
+        ),
+        BookUIModel(
+            isbn = "222",
+            title = "안드로이드 Compose 완벽 가이드",
+            author = "Compose 팀",
+            publisher = "구글",
+            thumbnail = ""
+        )
+    )
+
+    val pagingItems = flowOf(
+        PagingData.from(previewBooks)
+    ).collectAsLazyPagingItems()
+
+    And03Theme {
+        BookSearchScreen(
+            uiState = uiState,
+            searchResults = pagingItems,
+            onQueryChange = {},
+            onBackClick = {},
+            onItemClick = {},
+            onSaveClick = {},
+            onManualAddClick = {}
         )
     }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -32,8 +32,9 @@ import com.boostcamp.and03.ui.component.SearchResultItem
 import com.boostcamp.and03.ui.component.SearchTextField
 import com.boostcamp.and03.ui.component.SearchTopBar
 import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
+import com.boostcamp.and03.ui.theme.And03Padding
+import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
-import com.boostcamp.and03.ui.theme.Dimensions
 import kotlinx.coroutines.flow.flowOf
 
 @Composable
@@ -88,7 +89,7 @@ private fun BookSearchScreen(
             onSearch = { onQueryChange(searchTextState.text.toString()) },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(Dimensions.PADDING_M)
+                .padding(And03Padding.PADDING_M)
         )
 
         when {
@@ -109,8 +110,8 @@ private fun BookSearchScreen(
             else -> {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(horizontal = Dimensions.PADDING_L),
-                    verticalArrangement = Arrangement.spacedBy(Dimensions.PADDING_M)
+                    contentPadding = PaddingValues(horizontal = And03Padding.PADDING_L),
+                    verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_M)
                 ) {
                     items(
                         count = searchResults.itemCount,
@@ -149,7 +150,7 @@ private fun BookSearchEmptySection(
             color = And03Theme.colors.onSurfaceVariant
         )
 
-        Spacer(modifier = Modifier.height(Dimensions.PADDING_L))
+        Spacer(modifier = Modifier.height(And03Spacing.SPACE_L))
 
         And03Button(
             text = stringResource(R.string.book_search_button_text),

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchScreen.kt
@@ -9,14 +9,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -67,10 +66,13 @@ private fun BookSearchScreen(
     onManualAddClick: () -> Unit,
     modifier: Modifier= Modifier
 ) {
-    val searchTextState = rememberTextFieldState(uiState.query)
+    val searchTextState = remember { TextFieldState(uiState.query) }
 
-    LaunchedEffect(searchTextState.text) {
-        onQueryChange(searchTextState.text.toString())
+    LaunchedEffect(Unit) {
+        snapshotFlow { searchTextState.text.toString() }
+            .collect { text ->
+                onQueryChange(text)
+            }
     }
 
     Column(modifier = modifier.fillMaxSize()) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
@@ -7,7 +7,4 @@ data class BookSearchUiState(
 ) {
     val isSaveEnabled: Boolean
         get() = selectedBookISBN != null
-
-    val showManualAddButton: Boolean
-        get() = query.isBlank()
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
@@ -3,9 +3,7 @@ package com.boostcamp.and03.ui.screen.booksearch
 data class BookSearchUiState(
     val query: String = "",
     val selectedBookISBN: String? = null,
-    val isLoading: Boolean = false,
-    val isPaging: Boolean = false,
-    val hasNextPage: Boolean = false,
+    val isLoading: Boolean = false
 ) {
     val isSaveEnabled: Boolean
         get() = selectedBookISBN != null

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
@@ -1,0 +1,20 @@
+package com.boostcamp.and03.ui.screen.booksearch
+
+import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+data class BookSearchUiState(
+    val query: String = "",
+    val searchResults: ImmutableList<BookUIModel> = persistentListOf(),
+    val selectedBookISBN: String? = null,
+    val isLoading: Boolean = false,
+    val isPaging: Boolean = false,
+    val hasNextPage: Boolean = false,
+) {
+    val isSaveEnabled: Boolean
+        get() = selectedBookISBN != null
+
+    val showManualAddButton: Boolean
+        get() = query.isBlank()
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
@@ -6,7 +6,6 @@ import kotlinx.collections.immutable.persistentListOf
 
 data class BookSearchUiState(
     val query: String = "",
-    val searchResults: ImmutableList<BookUIModel> = persistentListOf(),
     val selectedBookISBN: String? = null,
     val isLoading: Boolean = false,
     val isPaging: Boolean = false,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchUiState.kt
@@ -1,9 +1,5 @@
 package com.boostcamp.and03.ui.screen.booksearch
 
-import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
-
 data class BookSearchUiState(
     val query: String = "",
     val selectedBookISBN: String? = null,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchViewModel.kt
@@ -1,0 +1,10 @@
+package com.boostcamp.and03.ui.screen.booksearch
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class BookSearchViewModel @Inject constructor(): ViewModel() {
+
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchViewModel.kt
@@ -1,10 +1,51 @@
 package com.boostcamp.and03.ui.screen.booksearch
 
 import androidx.lifecycle.ViewModel
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.boostcamp.and03.data.repository.book.BookRepository
+import com.boostcamp.and03.data.repository.book.toUiModel
+import com.boostcamp.and03.ui.screen.booklist.model.BookUIModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
-class BookSearchViewModel @Inject constructor(): ViewModel() {
+class BookSearchViewModel @Inject constructor(
+    private val bookRepository: BookRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(BookSearchUiState())
+    val uiState = _uiState.asStateFlow()
 
+    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+    val pagingBooksFlow: Flow<PagingData<BookUIModel>> =
+        _uiState
+            .map { it.query }
+            .debounce(300)
+            .distinctUntilChanged()
+            .filter { it.isNotBlank() }
+            .flatMapLatest { query ->
+                bookRepository.loadBooksPagingFlow(query)
+                    .map { pagingData ->
+                        pagingData.map { it.toUiModel() }
+                    }
+            }
+
+    fun changeQuery(query: String) {
+        _uiState.update { it.copy(query = query) }
+    }
+
+    fun clickItem(item: BookUIModel) {
+        _uiState.update { it.copy(selectedBookISBN = if (it.selectedBookISBN == item.isbn) null else item.isbn) }
+    }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchViewModel.kt
@@ -1,7 +1,9 @@
 package com.boostcamp.and03.ui.screen.booksearch
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import androidx.paging.map
 import com.boostcamp.and03.data.repository.book.BookRepository
 import com.boostcamp.and03.data.repository.book.toUiModel
@@ -28,18 +30,17 @@ class BookSearchViewModel @Inject constructor(
     val uiState = _uiState.asStateFlow()
 
     @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
-    val pagingBooksFlow: Flow<PagingData<BookUIModel>> =
-        _uiState
-            .map { it.query }
-            .debounce(300)
-            .distinctUntilChanged()
-            .filter { it.isNotBlank() }
-            .flatMapLatest { query ->
-                bookRepository.loadBooksPagingFlow(query)
-                    .map { pagingData ->
-                        pagingData.map { it.toUiModel() }
-                    }
-            }
+    val pagingBooksFlow: Flow<PagingData<BookUIModel>> = _uiState
+        .map { it.query }
+        .debounce(300)
+        .distinctUntilChanged()
+        .filter { it.isNotBlank() }
+        .flatMapLatest { query ->
+            bookRepository.loadBooksPagingFlow(query)
+                .map { pagingData ->
+                    pagingData.map { it.toUiModel() }
+                }
+        }
 
     fun changeQuery(query: String) {
         _uiState.update { it.copy(query = query) }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booksearch/BookSearchViewModel.kt
@@ -47,6 +47,14 @@ class BookSearchViewModel @Inject constructor(
     }
 
     fun clickItem(item: BookUIModel) {
-        _uiState.update { it.copy(selectedBookISBN = if (it.selectedBookISBN == item.isbn) null else item.isbn) }
+        _uiState.update {
+            it.copy(
+                selectedBookISBN = if (it.selectedBookISBN == item.isbn) {
+                    null
+                } else {
+                    item.isbn
+                }
+            )
+        }
     }
 }

--- a/app/src/main/res/drawable/ic_keyboard_arrow_left_filled.xml
+++ b/app/src/main/res/drawable/ic_keyboard_arrow_left_filled.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M15.41,16.59L10.83,12l4.58,-4.59L14,6l-6,6 6,6 1.41,-1.41z"/>
+    
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="editable_text_field_hint">책 제목을 입력하세요.</string>
     <string name="snackbar_save_book_success_message">책이 추가됐어요. 지금 메모를 남겨볼까요?</string>
     <string name="snackbar_save_book_success_action">메모 작성</string>
+
     <!-- 바텀 탭 문자열 -->
     <string name="bottom_tab_booklist">책 목록</string>
     <string name="bottom_tab_add_book">책 추가</string>
@@ -17,6 +18,12 @@
     <string name="ocr_bottom_sheet_take_a_photo_description">책 페이지를 직접 촬영합니다</string>
     <string name="ocr_bottom_sheet_select_image">이미지에서 가져오기</string>
     <string name="ocr_bottom_sheet_select_image_description">기기에 저장된 사진을 선택합니다</string>
+
+    <!-- 책 검색 화면 -->
+    <string name="book_search_title">책 추가</string>
+    <string name="book_search_empty_before_query">책을 직접 추가할 수 있어요.</string>
+    <string name="book_search_empty_after_query">검색 결과가 없어요.</string>
+    <string name="book_search_button_text">직접 추가</string>
 
     <!-- Content Description -->
     <string name="content_description_go_back">뒤로 가기</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,5 +24,5 @@
     <string name="content_description_open_gallery">갤러리에서 사진을 선택하여 텍스트를 가져옵니다</string>
     <string name="content_description_more_button">더보기 버튼을 눌러 메뉴를 표시합니다</string>
     <string name="content_description_node_item_icon">노드를 나타내는 아이콘입니다.</string>
-    <string name="content_description_"></string>
+    <string name="content_description_save_button">저장 버튼을 눌러 책을 저장합니다</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈
- #48

## 📝작업 내용
- [x] 임시 TopAppBar를 활용한 화면 UI 구현
- [x] 아이템 클릭 시 테두리 표시 
- [x] 검색 결과 페이징 출력
- [x] 검색 디바운싱 구현
- [x] 알라딘 API 연동([PR](https://github.com/boostcampwm2025/and03-boostcamp/pull/55)을 따로 작성하였습니다)
- [ ] 뒤로 가기 기능 구현
- [ ] 저장 기능 구현

## 🤔시행착오
- 동작을 확인하기 위해 진입점을 바꾸는 것을 시도했지만 앱이 크래시되는 문제가 있었습니다.
  - `@HiltViewModel`을 쓰는 Screen을 표시하기 위해서는 `@HiltAndroidApp`과 `@AndroidEntryPoint`가 필요했습니다.
  - 따라서 찬휘님의 PR을 머지한 다음에 시도하니 잘 실행됨을 확인했습니다.
- `@SerialName("")`에 불필요한 공백을 추가해버리는 실수로 인해 앱이 크래시되는 문제가 있었습니다.
  - 후... 여러분은 공백 넣지 마십쇼...

## 💬리뷰 요구사항
- 깔끔하지 않은 코드 포맷팅이나 바로 이해가 되지 않는 부분을 코멘트로 남겨주시면 피드백을 반영해보겠습니다!

## 🖼️동영상 및 스크린샷

- 테스트 영상입니다.
- `MainActivity`의 진입점을 `MainApp(navigator)`으로 수정하고
`MainNaviagtor` 내부의 `startDestination`을 `Route.BookSearch`로 수정하면 동작을 확인하실 수 있습니다.

https://github.com/user-attachments/assets/48c93efc-80b2-48ae-bc6a-f06d186681e9

- 현재 저장 버튼을 누르면 아이템 클릭 시 테두리 반영이 정상적으로 되지 않는 문제가 있습니다.
- 저장 기능을 구현할 때 해결할 수 있을 것으로 보입니다.

https://github.com/user-attachments/assets/5d78f11c-7c4c-4db9-abec-8663cae55d6c

- 일부 검색어의 경우 책의 제목에 검색어가 포함되지 않는 결과가 출력됨을 확인했습니다.
정렬 기준이 문제인가 싶어 [네이버 API 문서](https://developers.naver.com/docs/serviceapi/search/book/book.md)를 다시 확인해보니 기본값이 정확도순이었습니다...
- 웹에서는 어떻게 결과가 나올지 확인해봤더니 API 결과 값과 다르게 나왔습니다...

<img width="2559" height="1376" alt="스크린샷 2026-01-07 013430" src="https://github.com/user-attachments/assets/812a0c7a-8cbe-48a5-aae4-c9c7c482f43d" />

- 또한 원서를 번역한 책의 제목을 한글로 검색했을 때 결과가 나오지 않는 현상을 발견했습니다.
대신 영어로 검색하면 잘 나옵니다.

<img width="2559" height="1381" alt="스크린샷 2026-01-07 013519" src="https://github.com/user-attachments/assets/102d85ab-4580-48c4-8016-5174ffc5a4b9" />
<img width="400" alt="스크린샷 2026-01-07 013535" src="https://github.com/user-attachments/assets/2b619f97-40cb-468a-a44b-d7cb197db25d" />