### PR TITLE
책 상세화면 등장인물, 구절 컴포넌트 완료

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/MainActivity.kt
+++ b/app/src/main/java/com/boostcamp/and03/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import com.boostcamp.and03.ui.screen.prototype.navigation.PrototypeNavHost
+import com.boostcamp.and03.ui.navigation.rememberMainNavigator
 import com.boostcamp.and03.ui.theme.And03Theme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -15,9 +15,9 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             And03Theme {
-//                val navigator = rememberMainNavigator()
-//                MainApp(navigator)
-                PrototypeNavHost()
+                val navigator = rememberMainNavigator()
+                MainApp(navigator)
+//                PrototypeNavHost()
             }
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/MainApp.kt
+++ b/app/src/main/java/com/boostcamp/and03/MainApp.kt
@@ -23,14 +23,6 @@ fun MainApp(
 
     Scaffold(
         modifier = modifier,
-        bottomBar = {
-            MainBottomBar(
-                visible = navigator.isShowBottomBar,
-                tabs = navigator.mainBottomTabs,
-                currentTab = navigator.currentTab,
-                onTabSelected = { tab -> navigator.navigate(tab.route) }
-            )
-        },
         snackbarHost = { ActionSnackBarHost(hostState = snackBarHostState) },
         // contentWindowInsets = WindowInsets() // 최상위 Scaffold에서 WindowInset을 소비하지 않게 하여 Screen의 WindowInset만 소비할 수 있도록 함
     ) { innerPadding -> // 이 innerPadding은 탑바/바텀바의 영역만 갖고 옴

--- a/app/src/main/java/com/boostcamp/and03/ui/component/ActionSnackBar.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/ActionSnackBar.kt
@@ -7,7 +7,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import com.boostcamp.and03.ui.theme.And03Radius
 import com.boostcamp.and03.ui.theme.And03Theme
 
 @Composable
@@ -21,7 +21,7 @@ fun ActionSnackBarHost(
     ) { snackbarData ->
         Snackbar(
             snackbarData = snackbarData,
-            shape = RoundedCornerShape(12.dp),
+            shape = RoundedCornerShape(And03Radius.RADIUS_M),
             actionColor = And03Theme.colors.secondary,
             actionOnNewLine = false,
         )

--- a/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.and03.R
+import com.boostcamp.and03.ui.theme.And03Radius
 
 @Composable
 fun EditableTextField(
@@ -43,7 +44,7 @@ fun EditableTextField(
         ),
         onKeyboardAction = { onSearch() },
         lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = lineLimits),
-        shape = RoundedCornerShape(12.dp),
+        shape = RoundedCornerShape(And03Radius.RADIUS_M),
         colors = TextFieldDefaults.colors(
             focusedTextColor = MaterialTheme.colorScheme.onSurface,
             unfocusedTextColor = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/com/boostcamp/and03/ui/component/LabelAndEditableTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/LabelAndEditableTextField.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.and03.R
+import com.boostcamp.and03.ui.theme.And03Radius
+import com.boostcamp.and03.ui.theme.And03Spacing
 
 @Composable
 fun LabelAndEditableTextField(
@@ -35,7 +37,7 @@ fun LabelAndEditableTextField(
             style = MaterialTheme.typography.labelLarge,
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(And03Spacing.SPACE_S))
 
         EditableTextField(
             state = state,

--- a/app/src/main/java/com/boostcamp/and03/ui/component/LabelChip.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/LabelChip.kt
@@ -8,7 +8,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
+import com.boostcamp.and03.ui.theme.And03Padding
+import com.boostcamp.and03.ui.theme.And03Radius
 import com.boostcamp.and03.ui.theme.And03Theme
 
 @Composable
@@ -20,11 +22,11 @@ fun LabelChip(
         modifier = modifier
             .background(
                 color = And03Theme.colors.secondaryContainer,
-                shape = RoundedCornerShape(4.dp)
+                shape = RoundedCornerShape(And03Radius.RADIUS_XS)
             )
             .padding(
-                horizontal = 8.dp,
-                vertical = 2.dp
+                horizontal = And03Padding.PADDING_S,
+                vertical = And03Padding.PADDING_2XS
             )
     ) {
         Text(
@@ -33,4 +35,10 @@ fun LabelChip(
             color = And03Theme.colors.onSecondaryContainer
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun LabelChipPreview() {
+    LabelChip(text = "Label")
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/component/LabelChip.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/LabelChip.kt
@@ -1,0 +1,36 @@
+package com.boostcamp.and03.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.boostcamp.and03.ui.theme.And03Theme
+
+@Composable
+fun LabelChip(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .background(
+                color = And03Theme.colors.secondaryContainer,
+                shape = RoundedCornerShape(4.dp)
+            )
+            .padding(
+                horizontal = 8.dp,
+                vertical = 2.dp
+            )
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = And03Theme.colors.onSecondaryContainer
+        )
+    }
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import com.boostcamp.and03.ui.screen.addbook.addBookNavGraph
+import com.boostcamp.and03.ui.screen.bookdetail.bookDetailNavGraph
 import com.boostcamp.and03.ui.screen.booklist.booklistNavGraph
 import com.boostcamp.and03.ui.screen.mypage.myPageNavGraph
 import com.boostcamp.and03.ui.screen.prototype.screen.SnackBarEvent
@@ -23,11 +24,17 @@ fun MainNavHost(
     ) {
         booklistNavGraph(
             modifier = modifier.padding(paddingValues),
-            onShowSnackBar = onShowSnackBar
+            onShowSnackBar = onShowSnackBar,
+            navigateToBookDetail = {
+                navigator.navigate(MainTabRoute.BookDetail)
+            }
         )
 
         addBookNavGraph(modifier = modifier.padding(paddingValues))
 
         myPageNavGraph(modifier = modifier.padding(paddingValues))
+
+        bookDetailNavGraph(modifier = modifier.padding(paddingValues))
+
     }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavigator.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavigator.kt
@@ -23,7 +23,7 @@ class MainNavigator(
         @Composable get() =
             navController.currentBackStackEntryAsState().value?.destination
 
-    val startDestination = MainTabRoute.AddBook
+    val startDestination = MainTabRoute.Booklist
 
     val mainBottomTabs = MainBottomTab.entries.toImmutableList()
 

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavigator.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavigator.kt
@@ -52,6 +52,7 @@ class MainNavigator(
             MainTabRoute.Booklist -> navController.navigateBooklist(navOptions)
             MainTabRoute.AddBook -> navController.navigateAddBook(navOptions)
             MainTabRoute.MyPage -> navController.navigateMyPage(navOptions)
+            MainTabRoute.BookDetail -> navController.navigateBookDetail(navOptions)
         }
     }
 
@@ -65,6 +66,10 @@ class MainNavigator(
 
     fun NavController.navigateMyPage(navOptions: NavOptions) {
         navigate(MainTabRoute.MyPage, navOptions)
+    }
+
+    fun NavController.navigateBookDetail(navOptions: NavOptions) {
+        navigate(MainTabRoute.BookDetail, navOptions)
     }
 
     fun navigatePopBackStack() = navController.popBackStack()

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/Route.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/Route.kt
@@ -22,4 +22,8 @@ sealed interface MainTabRoute : Route {
 
     @Serializable
     data object MyPage : MainTabRoute
+
+    @Serializable
+    data object BookDetail : MainTabRoute
+
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/Route.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/Route.kt
@@ -11,6 +11,9 @@ sealed interface Route {
 
     @Serializable
     data object MyPage : Route
+
+    @Serializable
+    data object BookDetail : Route
 }
 
 sealed interface MainTabRoute : Route {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailNavGraph.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailNavGraph.kt
@@ -1,0 +1,14 @@
+package com.boostcamp.and03.ui.screen.bookdetail
+
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.boostcamp.and03.ui.navigation.MainTabRoute
+
+fun NavGraphBuilder.bookDetailNavGraph(
+    modifier: Modifier = Modifier
+) {
+    composable<MainTabRoute.Booklist> {
+        BookDetailRoute()
+    }
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailNavGraph.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailNavGraph.kt
@@ -8,7 +8,7 @@ import com.boostcamp.and03.ui.navigation.MainTabRoute
 fun NavGraphBuilder.bookDetailNavGraph(
     modifier: Modifier = Modifier
 ) {
-    composable<MainTabRoute.Booklist> {
+    composable<MainTabRoute.BookDetail> {
         BookDetailRoute()
     }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -29,6 +30,8 @@ import coil.compose.AsyncImage
 import com.boostcamp.and03.ui.screen.bookdetail.component.CharacterCard
 import com.boostcamp.and03.ui.screen.bookdetail.model.BookDetailTab
 import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
+import com.boostcamp.and03.ui.theme.And03Padding
+import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
 
 @Composable
@@ -99,29 +102,32 @@ private fun BookInfoSection(
     publisher: String
 ) {
     Row(
-        modifier = Modifier.padding(vertical = 24.dp)
+        modifier = Modifier.padding(And03Padding.PADDING_XL),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         AsyncImage(
             model = thumbnail,
             contentDescription = null,
             modifier = Modifier
-                .width(100.dp)
+                .width(80.dp)
                 .aspectRatio(2f / 3f),
             contentScale = ContentScale.Crop
         )
+        Spacer(modifier = Modifier.width(And03Spacing.SPACE_M))
         Column(
-            modifier = Modifier.padding(vertical = 24.dp),
+            modifier = Modifier.padding(vertical = And03Padding.PADDING_2XL),
         ) {
             Text(
                 text = title,
                 style = And03Theme.typography.titleLarge
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(And03Spacing.SPACE_S))
             Text(
                 text = author,
                 style = And03Theme.typography.bodyMedium,
                 color = And03Theme.colors.secondary
             )
+            Spacer(modifier = Modifier.height(And03Spacing.SPACE_XS))
             Text(
                 text = publisher,
                 style = And03Theme.typography.bodySmall,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
@@ -1,0 +1,182 @@
+package com.boostcamp.and03.ui.screen.bookdetail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.boostcamp.and03.ui.screen.bookdetail.component.CharacterCard
+import com.boostcamp.and03.ui.screen.bookdetail.model.BookDetailTab
+import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
+import com.boostcamp.and03.ui.theme.And03Theme
+
+@Composable
+fun BookDetailRoute(
+    viewModel: BookDetailViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    BookDetailScreen(
+        uiState = uiState,
+    )
+}
+
+@Composable
+private fun BookDetailScreen(uiState: BookDetailUiState) {
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    val tabs = BookDetailTab.entries
+
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        SecondaryTabRow(
+            selectedTabIndex = selectedTabIndex,
+            containerColor = And03Theme.colors.surface,
+            contentColor = And03Theme.colors.onSurface,
+            indicator = {
+                TabRowDefaults.SecondaryIndicator(
+                    modifier = Modifier.tabIndicatorOffset(selectedTabIndex),
+                    color = And03Theme.colors.primary
+                )
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            tabs.forEachIndexed { index, tab ->
+                androidx.compose.material3.Tab(
+                    selected = selectedTabIndex == index,
+                    onClick = { selectedTabIndex = index },
+                    text = {
+                        Text(
+                            text = tab.title
+                        )
+                    }
+                )
+            }
+        }
+
+        when (tabs[selectedTabIndex]) {
+            BookDetailTab.CHARACTER -> CharacterTab(uiState)
+            BookDetailTab.QUOTE -> ImpressiveQuoteTab()
+            BookDetailTab.MEMO -> MemoTab()
+        }
+
+    }
+}
+
+@Composable
+private fun BookInfoSection(
+    thumbnail: String,
+    title: String,
+    author: String,
+    publisher: String
+) {
+    Row(
+        modifier = Modifier.padding(vertical = 24.dp)
+    ) {
+        AsyncImage(
+            model = thumbnail,
+            contentDescription = null,
+            modifier = Modifier
+                .width(100.dp)
+                .aspectRatio(2f / 3f),
+            contentScale = ContentScale.Crop
+        )
+        Column(
+            modifier = Modifier.padding(vertical = 24.dp),
+        ) {
+            Text(
+                text = title,
+                style = And03Theme.typography.titleLarge
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = author,
+                style = And03Theme.typography.bodyMedium,
+                color = And03Theme.colors.secondary
+            )
+            Text(
+                text = publisher,
+                style = And03Theme.typography.bodySmall,
+                color = And03Theme.colors.secondary
+            )
+        }
+    }
+}
+
+@Composable
+private fun CharacterTab(
+    uiState: BookDetailUiState
+) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        uiState.characters.forEach { character ->
+            CharacterCard(
+                name = character.name,
+                role = character.role,
+                iconColor = character.iconColor,
+                description = character.description,
+                onMoreClick = { }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ImpressiveQuoteTab() {
+}
+
+@Composable
+private fun MemoTab() {
+
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun BooklistScreenPreview() {
+    val previewState = BookDetailUiState(
+        characters = listOf(
+            CharacterUiModel(
+                name = "해리 포터",
+                role = "주인공",
+                iconColor = Color(0xFF1E88E5),
+                description = "호그와트의 마법사 학생으로 볼드모트와 맞서 싸우는 주인공"
+            ),
+            CharacterUiModel(
+                name = "헤르미온느 그레인저",
+                role = "조연",
+                iconColor = Color(0xFF8E24AA),
+                description = "뛰어난 마법 실력을 가진 해리의 절친한 친구"
+            )
+        )
+    )
+
+    And03Theme {
+        BookDetailScreen(
+            uiState = previewState,
+        )
+    }
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
@@ -28,6 +28,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.boostcamp.and03.ui.screen.bookdetail.component.CharacterCard
+import com.boostcamp.and03.ui.screen.bookdetail.component.QuoteCard
 import com.boostcamp.and03.ui.screen.bookdetail.model.BookDetailTab
 import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
 import com.boostcamp.and03.ui.theme.And03Padding
@@ -87,7 +88,7 @@ private fun BookDetailScreen(uiState: BookDetailUiState) {
 
         when (tabs[selectedTabIndex]) {
             BookDetailTab.CHARACTER -> CharacterTab(uiState)
-            BookDetailTab.QUOTE -> ImpressiveQuoteTab()
+            BookDetailTab.QUOTE -> QuoteTab(uiState)
             BookDetailTab.MEMO -> MemoTab()
         }
 
@@ -138,9 +139,7 @@ private fun BookInfoSection(
 }
 
 @Composable
-private fun CharacterTab(
-    uiState: BookDetailUiState
-) {
+private fun CharacterTab(uiState: BookDetailUiState) {
     Column(
         modifier = Modifier.padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -158,7 +157,15 @@ private fun CharacterTab(
 }
 
 @Composable
-private fun ImpressiveQuoteTab() {
+private fun QuoteTab(uiState: BookDetailUiState) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        uiState.quotes.forEach { quote ->
+            QuoteCard(quote = quote)
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
@@ -78,9 +78,7 @@ private fun BookDetailScreen(uiState: BookDetailUiState) {
                     selected = selectedTabIndex == index,
                     onClick = { selectedTabIndex = index },
                     text = {
-                        Text(
-                            text = tab.title
-                        )
+                        Text(text = tab.title)
                     }
                 )
             }
@@ -141,8 +139,8 @@ private fun BookInfoSection(
 @Composable
 private fun CharacterTab(uiState: BookDetailUiState) {
     Column(
-        modifier = Modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        modifier = Modifier.padding(And03Padding.PADDING_L),
+        verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_M)
     ) {
         uiState.characters.forEach { character ->
             CharacterCard(
@@ -159,8 +157,8 @@ private fun CharacterTab(uiState: BookDetailUiState) {
 @Composable
 private fun QuoteTab(uiState: BookDetailUiState) {
     Column(
-        modifier = Modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        modifier = Modifier.padding(And03Padding.PADDING_L),
+        verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_M)
     ) {
         uiState.quotes.forEach { quote ->
             QuoteCard(quote = quote)

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
@@ -50,6 +50,13 @@ private fun BookDetailScreen(uiState: BookDetailUiState) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
+        BookInfoSection(
+            thumbnail = uiState.thumbnail,
+            title = uiState.title,
+            author = uiState.author,
+            publisher = uiState.publisher
+        )
+
         SecondaryTabRow(
             selectedTabIndex = selectedTabIndex,
             containerColor = And03Theme.colors.surface,
@@ -158,6 +165,10 @@ private fun MemoTab() {
 @Composable
 fun BooklistScreenPreview() {
     val previewState = BookDetailUiState(
+        thumbnail = "https://i.pinimg.com/736x/8f/20/41/8f2041520696507bc2bfd2f5648c8da3.jpg",
+        title = "Harry Potter and the Philosopher's Stone",
+        author = "J.K. Rowling",
+        publisher = "Bloomsbury Publishing",
         characters = listOf(
             CharacterUiModel(
                 name = "해리 포터",

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailUiState.kt
@@ -1,11 +1,13 @@
 package com.boostcamp.and03.ui.screen.bookdetail
 
 import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
+import com.boostcamp.and03.ui.screen.bookdetail.model.QuoteUiModel
 
 data class BookDetailUiState(
     val thumbnail: String = "",
     val title: String = "",
     val author: String = "",
     val publisher: String = "",
-    val characters: List<CharacterUiModel> = emptyList()
+    val characters: List<CharacterUiModel> = emptyList(),
+    val quotes: List<QuoteUiModel> = emptyList(),
 )

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailUiState.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.and03.ui.screen.bookdetail
+
+import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
+
+data class BookDetailUiState(
+    val thumbnail: String = "",
+    val title: String = "",
+    val author: String = "",
+    val publisher: String = "",
+    val characters: List<CharacterUiModel> = emptyList()
+)

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.boostcamp.and03.ui.screen.bookdetail
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
 import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
+import com.boostcamp.and03.ui.screen.bookdetail.model.QuoteUiModel
 import jakarta.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -34,6 +35,26 @@ class BookDetailViewModel @Inject constructor() : ViewModel() {
                     role = "조연",
                     iconColor = Color(0xFF8E24AA),
                     description = "해리의 절친한 친구"
+                )
+            ),
+            quotes = listOf(
+                QuoteUiModel(
+                    "1",
+                    "이 책을 읽으면서 꿈에 대한 새로운 관점을 얻게 되었다. 꿈이 단순히 무의식의 산물이 아니라 우리가 구매할 수 있는 상품이라는 설정이 흥미롭다.",
+                    26,
+                    "2024.01.10"
+                ),
+                QuoteUiModel(
+                    "2",
+                    "이 책을 읽으면서 꿈에 대한 새로운 관점을 얻게 되었다. 꿈이 단순히 무의식의 산물이 아니라 우리가 구매할 수 있는 상품이라는 설정이 흥미롭다.",
+                    26,
+                    "2024.01.10"
+                ),
+                QuoteUiModel(
+                    "3",
+                    "이 책을 읽으면서 꿈에 대한 새로운 관점을 얻게 되었다. 꿈이 단순히 무의식의 산물이 아니라 우리가 구매할 수 있는 상품이라는 설정이 흥미롭다.",
+                    26,
+                    "2024.01.10"
                 )
             )
         )

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailViewModel.kt
@@ -9,23 +9,33 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class BookDetailViewModel @Inject constructor() : ViewModel() {
-    private val _uiState = MutableStateFlow(
-        BookDetailUiState(
+    private val _uiState = MutableStateFlow(BookDetailUiState())
+    val uiState: StateFlow<BookDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        initPreviewData()
+    }
+
+    private fun initPreviewData() {
+        _uiState.value = BookDetailUiState(
+            thumbnail = "https://i.pinimg.com/736x/8f/20/41/8f2041520696507bc2bfd2f5648c8da3.jpg",
+            title = "Harry Potter and the Philosopher's Stone",
+            author = "J.K. Rowling",
+            publisher = "Bloomsbury Publishing",
             characters = listOf(
                 CharacterUiModel(
                     name = "해리 포터",
                     role = "주인공",
                     iconColor = Color(0xFF1E88E5),
-                    description = "호그와트의 마법사 학생으로 볼드모트와 맞서 싸우는 주인공"
+                    description = "호그와트의 마법사 학생"
                 ),
                 CharacterUiModel(
                     name = "헤르미온느 그레인저",
                     role = "조연",
                     iconColor = Color(0xFF8E24AA),
-                    description = "뛰어난 마법 실력을 가진 해리의 절친한 친구"
+                    description = "해리의 절친한 친구"
                 )
             )
         )
-    )
-    val uiState: StateFlow<BookDetailUiState> = _uiState.asStateFlow()
+    }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailViewModel.kt
@@ -1,0 +1,31 @@
+package com.boostcamp.and03.ui.screen.bookdetail
+
+import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.ViewModel
+import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class BookDetailViewModel @Inject constructor() : ViewModel() {
+    private val _uiState = MutableStateFlow(
+        BookDetailUiState(
+            characters = listOf(
+                CharacterUiModel(
+                    name = "해리 포터",
+                    role = "주인공",
+                    iconColor = Color(0xFF1E88E5),
+                    description = "호그와트의 마법사 학생으로 볼드모트와 맞서 싸우는 주인공"
+                ),
+                CharacterUiModel(
+                    name = "헤르미온느 그레인저",
+                    role = "조연",
+                    iconColor = Color(0xFF8E24AA),
+                    description = "뛰어난 마법 실력을 가진 해리의 절친한 친구"
+                )
+            )
+        )
+    )
+    val uiState: StateFlow<BookDetailUiState> = _uiState.asStateFlow()
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/component/CharacterCard.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/component/CharacterCard.kt
@@ -1,0 +1,114 @@
+package com.boostcamp.and03.ui.screen.bookdetail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.and03.R
+import com.boostcamp.and03.ui.component.IconBadge
+import com.boostcamp.and03.ui.component.LabelChip
+
+@Composable
+fun CharacterCard(
+    name: String,
+    role: String,
+    iconColor: Color,
+    description: String,
+    onMoreClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = Color.White,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .border(
+                width = 1.dp,
+                color = Color(0xFFE0E0E0),
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(12.dp)
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // 프로필 아이콘
+                IconBadge(
+                    iconResId = R.drawable.ic_person_filled,
+                    iconColor = iconColor,
+                    contentDescription = "$name profile",
+                    size = 48.dp
+                )
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // 이름 + 역할
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = name,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    LabelChip(text = role)
+                }
+
+                IconButton(onClick = onMoreClick) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_more_vert_filled),
+                        contentDescription = "more"
+                    )
+                }
+            }
+
+            // 설명
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFF616161)
+            )
+        }
+    }
+}
+
+
+
+@Preview(showBackground = true)
+@Composable
+fun CharacterCardPreview() {
+    CharacterCard(
+        name = "Character Name",
+        role = "Character Role",
+        iconColor = Color(0xFF1E88E5),
+        description = "Character Description",
+        onMoreClick = {}
+    )
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/component/CharacterCard.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/component/CharacterCard.kt
@@ -21,12 +21,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.IconBadge
 import com.boostcamp.and03.ui.component.LabelChip
+import com.boostcamp.and03.ui.theme.And03IconSize
+import com.boostcamp.and03.ui.theme.And03Padding
+import com.boostcamp.and03.ui.theme.And03Radius
+import com.boostcamp.and03.ui.theme.And03Spacing
+import com.boostcamp.and03.ui.theme.And03Theme
 
 @Composable
 fun CharacterCard(
@@ -41,18 +47,18 @@ fun CharacterCard(
         modifier = modifier
             .fillMaxWidth()
             .background(
-                color = Color.White,
-                shape = RoundedCornerShape(12.dp)
+                color = And03Theme.colors.surface,
+                shape = RoundedCornerShape(And03Radius.RADIUS_S)
             )
             .border(
                 width = 1.dp,
-                color = Color(0xFFE0E0E0),
-                shape = RoundedCornerShape(12.dp)
+                color = And03Theme.colors.surface,
+                shape = RoundedCornerShape(And03Radius.RADIUS_S)
             )
-            .padding(12.dp)
+            .padding(And03Padding.PADDING_M)
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(And03Padding.PADDING_M)
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically
@@ -61,11 +67,14 @@ fun CharacterCard(
                 IconBadge(
                     iconResId = R.drawable.ic_person_filled,
                     iconColor = iconColor,
-                    contentDescription = "$name profile",
-                    size = 48.dp
+                    contentDescription = stringResource(
+                        id = R.string.character_card_profile_icon_cd,
+                        name
+                    ),
+                    size = And03IconSize.ICON_SIZE_L
                 )
 
-                Spacer(modifier = Modifier.width(8.dp))
+                Spacer(modifier = Modifier.width(And03Spacing.SPACE_S))
 
                 // 이름 + 역할
                 Column(
@@ -76,7 +85,7 @@ fun CharacterCard(
                         style = MaterialTheme.typography.titleMedium
                     )
 
-                    Spacer(modifier = Modifier.height(4.dp))
+                    Spacer(modifier = Modifier.height(And03Spacing.SPACE_XS))
 
                     LabelChip(text = role)
                 }
@@ -84,7 +93,7 @@ fun CharacterCard(
                 IconButton(onClick = onMoreClick) {
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_more_vert_filled),
-                        contentDescription = "more"
+                        contentDescription = stringResource(R.string.cd_more_options)
                     )
                 }
             }
@@ -98,7 +107,6 @@ fun CharacterCard(
         }
     }
 }
-
 
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/component/QuoteCard.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/component/QuoteCard.kt
@@ -1,0 +1,68 @@
+package com.boostcamp.and03.ui.screen.bookdetail.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.and03.ui.screen.bookdetail.model.QuoteUiModel
+import com.boostcamp.and03.ui.theme.And03Padding
+import com.boostcamp.and03.ui.theme.And03Radius
+import com.boostcamp.and03.ui.theme.And03Theme
+
+@Composable
+fun QuoteCard(quote: QuoteUiModel) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(And03Radius.RADIUS_M),
+        colors = CardDefaults.cardColors(containerColor = And03Theme.colors.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(And03Padding.PADDING_XL)
+        ) {
+            Text(
+                text = quote.content,
+                style = And03Theme.typography.bodyMedium,
+                color = And03Theme.colors.onSurface,
+                modifier = Modifier.padding(bottom = And03Padding.PADDING_2XL)
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "p.${quote.page}",
+                    style = And03Theme.typography.bodySmall,
+                    color = And03Theme.colors.secondary
+                )
+                Text(
+                    text = quote.date,
+                    style = And03Theme.typography.bodySmall,
+                    color = And03Theme.colors.secondary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun QuoteCardPreview() {
+    QuoteCard(
+        quote = QuoteUiModel(
+            id = "1",
+            content = "이 책을 읽으면서 꿈에 대한 새로운 관점을 얻게 되었다. 꿈이 단순히 무의식의 산물이 아니라 우리가 구매할 수 있는 상품이라는 설정이 흥미롭다.",
+            page = 26,
+            date = "2026.1.7"
+        )
+    )
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/component/QuoteCard.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/component/QuoteCard.kt
@@ -11,8 +11,10 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.screen.bookdetail.model.QuoteUiModel
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Radius
@@ -40,7 +42,10 @@ fun QuoteCard(quote: QuoteUiModel) {
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Text(
-                    text = "p.${quote.page}",
+                    text = stringResource(
+                        id = R.string.page_indicator,
+                        quote.page
+                    ),
                     style = And03Theme.typography.bodySmall,
                     color = And03Theme.colors.secondary
                 )

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/model/BookDetailTab.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/model/BookDetailTab.kt
@@ -1,0 +1,7 @@
+package com.boostcamp.and03.ui.screen.bookdetail.model
+
+enum class BookDetailTab(val title: String) {
+    CHARACTER("등장인물"),
+    QUOTE("인상깊은 구절"),
+    MEMO("메모")
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/model/CharacterUiModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/model/CharacterUiModel.kt
@@ -1,0 +1,11 @@
+package com.boostcamp.and03.ui.screen.bookdetail.model
+
+import androidx.compose.ui.graphics.Color
+
+
+data class CharacterUiModel(
+    val name: String,
+    val role: String,
+    val iconColor: Color,
+    val description: String
+)

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/model/QuoteUiModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/model/QuoteUiModel.kt
@@ -1,0 +1,8 @@
+package com.boostcamp.and03.ui.screen.bookdetail.model
+
+data class QuoteUiModel(
+    val id: String,
+    val content: String,
+    val page: Int,
+    val date: String
+)

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/BooklistNavGraph.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/BooklistNavGraph.kt
@@ -7,9 +7,14 @@ import com.boostcamp.and03.ui.navigation.MainTabRoute
 
 fun NavGraphBuilder.booklistNavGraph(
     onShowSnackBar: (message: String, actionLabel: String) -> Unit,
+    navigateToBookDetail: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     composable<MainTabRoute.Booklist> {
-        BooklistRoute()
+        BooklistRoute(
+            onBookClick = {
+                navigateToBookDetail()
+            }
+        )
     }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/theme/Dimen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/theme/Dimen.kt
@@ -14,6 +14,7 @@ object And03Spacing {
 }
 
 object And03Padding {
+    val PADDING_2XS = 2.dp
     val PADDING_XS = 4.dp
     val PADDING_S = 8.dp
     val PADDING_M = 12.dp

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,16 @@
 <resources>
     <string name="app_name">and03</string>
 
+    <!--  common  -->
+    <string name="cd_more_options">더보기 옵션</string>
+    <string name="page_indicator">p.%1$d</string>
+
     <!--  component  -->
     <string name="search_text_field_hint">검색어를 입력하세요.</string>
     <string name="editable_text_field_hint">책 제목을 입력하세요.</string>
     <string name="snackbar_save_book_success_message">책이 추가됐어요. 지금 메모를 남겨볼까요?</string>
     <string name="snackbar_save_book_success_action">메모 작성</string>
+
     <!-- 바텀 탭 문자열 -->
     <string name="bottom_tab_booklist">책 목록</string>
     <string name="bottom_tab_add_book">책 추가</string>
@@ -13,6 +18,7 @@
 
     <!-- book list -->
     <string name="book_count_text">총 %1$d권의 책</string>
+    <string name="character_card_profile_icon_cd">%1$s 프로필</string>
 
     <!-- OCR 바텀 시트 문자열 -->
     <string name="ocr_bottom_sheet_import_text">텍스트 가져오기</string>


### PR DESCRIPTION
## #️⃣연관된 이슈
- #50 : 책 상새화면 구현

## 📝작업 내용
- LabelChip 공통 UI 컴포넌트 추가 및 디자인 시스템(And03Theme) 적용
    - 지금 보니까 글자 색상이 달라서 수정해야겠네요... 
<img width="118" height="65" alt="image" src="https://github.com/user-attachments/assets/193a9804-de06-4b1e-b21e-d9014294306f" />
<img width="153" height="65" alt="image" src="https://github.com/user-attachments/assets/78072e49-6d17-4249-a07e-cc394122aecb" />

- 책 상세 화면 네비게이션 연결 및 초기 데이터 환경 구축

- 책 정보 섹션 구현

- 탭 메뉴 구현

- 등장인물 탭 UI 모델 정의 및 카드 컴포넌트, ViewModel 구현

- 인상 깊은 구절 탭 및 문장 카드 컴포넌트 구현



## 🖼️스크린샷 (선택)


https://github.com/user-attachments/assets/39837cfb-704b-4a93-9e88-828ecf117ffd


