### PR TITLE
페이지 리스트 스크롤 컴포넌트 구현

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/PagelistScroll.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/PagelistScroll.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.boostcamp.and03.ui.component.LabelChip
@@ -25,6 +26,7 @@ import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import com.boostcamp.and03.R
 
 @Composable
 fun PagelistScroll(
@@ -69,6 +71,19 @@ private fun PagelistItem(
     endPage: Int,
     modifier: Modifier = Modifier
 ) {
+    val pageText = if (startPage == endPage) {
+        stringResource(
+            id = R.string.canvas_memo_editor_page_list_scroll_single_page,
+            startPage
+        )
+    } else {
+        stringResource(
+            id = R.string.canvas_memo_editor_page_list_scroll_page_range,
+            startPage,
+            endPage
+        )
+    }
+
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_S),
@@ -76,7 +91,7 @@ private fun PagelistItem(
     ) {
         LabelChip {
             Text(
-                text = "p.$startPage~$endPage",
+                text = pageText,
                 style = And03Theme.typography.labelSmall,
                 color = And03Theme.colors.onSecondaryContainer
             )
@@ -100,7 +115,7 @@ private fun PagelistScrollPreview() {
                 memoId = "memo-1",
                 title = "캔버스 메모 아이템을 보여주는 리스트 스크롤 컴포넌트입니다.",
                 startPage = 1,
-                endPage = 26
+                endPage = 1
             ),
             CanvasMemoSummaryUiModel(
                 memoId = "memo-2",

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/PagelistScroll.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/PagelistScroll.kt
@@ -85,7 +85,7 @@ private fun PagelistItem(
     }
 
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_S),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/PagelistScroll.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/PagelistScroll.kt
@@ -1,0 +1,145 @@
+package com.boostcamp.and03.ui.screen.canvasmemo.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import com.boostcamp.and03.ui.component.LabelChip
+import com.boostcamp.and03.ui.component.drawVerticalScrollbar
+import com.boostcamp.and03.ui.screen.canvasmemo.model.CanvasMemoSummaryUiModel
+import com.boostcamp.and03.ui.theme.And03ComponentSize
+import com.boostcamp.and03.ui.theme.And03Padding
+import com.boostcamp.and03.ui.theme.And03Spacing
+import com.boostcamp.and03.ui.theme.And03Theme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+fun PagelistScroll(
+    items: ImmutableList<CanvasMemoSummaryUiModel>,
+    onItemClick: (CanvasMemoSummaryUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+
+    LazyColumn(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(max = And03ComponentSize.PAGE_LIST_SCROLL)
+            .padding(And03Padding.PADDING_XS)
+            .drawVerticalScrollbar(listState, color = And03Theme.colors.outlineVariant),
+        verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_M),
+        contentPadding = PaddingValues(
+            vertical = And03Spacing.SPACE_M,
+            horizontal = And03Spacing.SPACE_M
+        )
+    ) {
+        items(
+            items = items,
+            key = { it.memoId }
+        ) { item ->
+            PagelistItem(
+                title = item.title,
+                startPage = item.startPage,
+                endPage = item.endPage,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onItemClick(item) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun PagelistItem(
+    title: String,
+    startPage: Int,
+    endPage: Int,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_S),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        LabelChip {
+            Text(
+                text = "p.$startPage~$endPage",
+                style = And03Theme.typography.labelSmall,
+                color = And03Theme.colors.onSecondaryContainer
+            )
+        }
+
+        Text(
+            text = title,
+            style = And03Theme.typography.labelSmall,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PagelistScrollPreview() {
+    PagelistScroll(
+        items = persistentListOf(
+            CanvasMemoSummaryUiModel(
+                memoId = "memo-1",
+                title = "캔버스 메모 아이템을 보여주는 리스트 스크롤 컴포넌트입니다.",
+                startPage = 1,
+                endPage = 26
+            ),
+            CanvasMemoSummaryUiModel(
+                memoId = "memo-2",
+                title = "페이지 범위 정보와 메모 제목을 출력하죠.",
+                startPage = 5,
+                endPage = 10
+            ),
+            CanvasMemoSummaryUiModel(
+                memoId = "memo-3",
+                title = "긴 메모 제목도 이렇게 들어올 수 있어요. 그런데 만약 화면 범위를 넘는 제목의 경우, 말줄임표 처리가 돼요.",
+                startPage = 30,
+                endPage = 45
+            ),
+            CanvasMemoSummaryUiModel(
+                memoId = "memo-4",
+                title = "인터랙션 모드를 쓰면 스크롤 체험도 가능해요!",
+                startPage = 50,
+                endPage = 60
+            ),
+            CanvasMemoSummaryUiModel(
+                memoId = "memo-5",
+                title = "숨겨진 메모도 스크롤해서 확인해보세요!",
+                startPage = 61,
+                endPage = 70
+            ),
+            CanvasMemoSummaryUiModel(
+                memoId = "memo-6",
+                title = "6번째 메모",
+                startPage = 61,
+                endPage = 70
+            ),
+            CanvasMemoSummaryUiModel(
+                memoId = "memo-7",
+                title = "7번째 메모",
+                startPage = 61,
+                endPage = 70
+            )
+
+        ),
+        onItemClick = {}
+    )
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/model/CanvasMemoSummaryUiModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/model/CanvasMemoSummaryUiModel.kt
@@ -1,0 +1,17 @@
+package com.boostcamp.and03.ui.screen.canvasmemo.model
+
+import com.boostcamp.and03.data.model.response.memo.CanvasMemoResponse
+
+data class CanvasMemoSummaryUiModel (
+    val memoId: String,
+    val startPage: Int,
+    val endPage: Int,
+    val title: String
+)
+
+fun CanvasMemoResponse.toSummaryUiModel() = CanvasMemoSummaryUiModel(
+    memoId = id,
+    startPage = startPage,
+    endPage = endPage,
+    title = title
+)

--- a/app/src/main/java/com/boostcamp/and03/ui/theme/Dimen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/theme/Dimen.kt
@@ -44,6 +44,7 @@ object And03ComponentSize {
     val QUOTE_LEFT_BAR_HEIGHT = 48.dp
     val BUTTON_HEIGHT_L = 52.dp
     val TEXT_FIELD_HEIGHT_L = 140.dp
+    val PAGE_LIST_SCROLL = 160.dp
 }
 
 object And03Border {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@
     <string name="relation_name_placeholder">관계 이름을 입력하세요.</string>
     <string name="relation_dialog_title">관계 추가</string>
     <string name="relation_dialog_question_format">%1$s 와 %2$s 은 어떤 관계인가요?</string>
+    <string name="canvas_memo_editor_page_list_scroll_page_range">p.%1$d~%2$d</string>
+    <string name="canvas_memo_editor_page_list_scroll_single_page">p.%1$d</string>
 
     <!-- Content Description -->
     <string name="content_description_go_back">뒤로 가기</string>


### PR DESCRIPTION
## #️⃣연관된 이슈
- #이슈번호1: #83 

## 📝작업 내용
- 페이지 리스트 스크롤 컴포넌트 구현
- [x] 캔버스 메모 페이지 정보를 LabelChip으로 출력
- [x] 캔버스 메모 제목 정보를 Text로 출력
- [x] 위아래로 스크롤 시 스크롤바를 출력

## 🖼️스크린샷 (선택)

<img width="813" height="379" alt="image" src="https://github.com/user-attachments/assets/fc9c0905-f673-4834-8e5a-33ebce01f0c7" />