### PR TITLE
노드 추가 바텀시트 구현

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/ui/component/AddNodeBottomSheet.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/AddNodeBottomSheet.kt
@@ -1,0 +1,183 @@
+package com.boostcamp.and03.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.boostcamp.and03.R
+import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
+import com.boostcamp.and03.ui.theme.And03ComponentSize
+import com.boostcamp.and03.ui.theme.And03Padding
+import com.boostcamp.and03.ui.theme.And03Radius
+import com.boostcamp.and03.ui.theme.And03Spacing
+import com.boostcamp.and03.ui.theme.And03Theme
+import com.boostcamp.and03.ui.util.drawVerticalScrollbar
+
+
+@Composable
+fun AddNodeBottomSheet(
+    characters: List<CharacterUiModel>,
+    infoTitle: String,
+    infoDescription: String,
+    onSearch: (String) -> Unit,
+    onNewCharacterClick: () -> Unit,
+    onAddClick: (CharacterUiModel?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val searchState = rememberTextFieldState()
+    val listState = rememberLazyListState()
+    var selectedCharacterId by remember { mutableStateOf<String?>(null) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = And03Theme.colors.background,
+                shape = RoundedCornerShape(
+                    topStart = And03Radius.RADIUS_L,
+                    topEnd = And03Radius.RADIUS_L
+                )
+            )
+            .padding(
+                horizontal = And03Padding.PADDING_L,
+                vertical = And03Padding.PADDING_M
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        Box(
+            modifier = Modifier
+                .width(40.dp)
+                .height(4.dp)
+                .background(
+                    color = And03Theme.colors.outlineVariant,
+                    shape = RoundedCornerShape(And03Radius.RADIUS_S)
+                )
+        )
+
+        Spacer(modifier = Modifier.height(And03Spacing.SPACE_L))
+
+        Text(
+            text = stringResource(R.string.add_node_bottom_sheet_title),
+            style = And03Theme.typography.titleMedium,
+            color = And03Theme.colors.onBackground
+        )
+
+        Spacer(modifier = Modifier.height(And03Spacing.SPACE_L))
+
+        And03InfoSection(
+            title = infoTitle,
+            description = infoDescription
+        )
+
+        Spacer(modifier = Modifier.height(And03Spacing.SPACE_M))
+
+        SearchTextField(
+            state = searchState,
+            onSearch = { onSearch(searchState.text.toString()) },
+            modifier = Modifier.fillMaxWidth(),
+            placeholderRes = R.string.add_node_bottom_sheet_search_placeholder
+        )
+
+        Spacer(modifier = Modifier.height(And03Spacing.SPACE_M))
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .weight(1f)
+                .drawVerticalScrollbar(
+                    state = listState,
+                    color = And03Theme.colors.outlineVariant
+                ),
+            verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_S),
+            contentPadding = PaddingValues(bottom = And03Padding.PADDING_M)
+        ) {
+            items(
+                items = characters,
+                key = { it.id }
+            ) { character ->
+                CharacterCard(
+                    name = character.name,
+                    role = character.role,
+                    iconColor = character.iconColor,
+                    description = character.description,
+                    selected = selectedCharacterId == character.id,
+                    onClick = { selectedCharacterId = character.id },
+                    onEditClick = {},
+                    onDeleteClick = {}
+                )
+            }
+        }
+
+        TextButton(
+            onClick = onNewCharacterClick,
+            modifier = Modifier.padding(vertical = And03Spacing.SPACE_S)
+        ) {
+            Text(
+                text = stringResource(R.string.add_node_bottom_sheet_new_character),
+                style = And03Theme.typography.labelLarge,
+                color = And03Theme.colors.primary
+            )
+        }
+
+        And03Button(
+            text = stringResource(R.string.add_node_bottom_sheet_add_button),
+            onClick = {
+                val selected = characters.find { it.id == selectedCharacterId }
+                onAddClick(selected)
+            },
+            variant = ButtonVariant.Primary,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(And03ComponentSize.BUTTON_HEIGHT_L)
+        )
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun AddNodeBottomSheetPreview() {
+    And03Theme {
+        AddNodeBottomSheet(
+            characters = List(8) {
+                CharacterUiModel(
+                    id = it.toString(),
+                    name = "헤르미온느 그레인저",
+                    role = "조연",
+                    description = "뛰어난 마법 실력을 가진 해리의 친구",
+                    iconColor = Color(0xFF4CAF50)
+                )
+            },
+            infoTitle = "등장인물을 선택해 노드를 추가해주세요.",
+            infoDescription = "아직 등록하지 않았다면 새로 추가할 수 있어요.",
+            onSearch = {},
+            onNewCharacterClick = {},
+            onAddClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/component/AddQuoteBottomSheet.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/AddQuoteBottomSheet.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -30,13 +29,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.screen.bookdetail.model.QuoteUiModel

--- a/app/src/main/java/com/boostcamp/and03/ui/component/AddQuoteBottomSheet.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/AddQuoteBottomSheet.kt
@@ -47,6 +47,7 @@ import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Radius
 import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
+import com.boostcamp.and03.ui.util.drawVerticalScrollbar
 
 @Composable
 fun AddQuoteBottomSheet(
@@ -168,29 +169,6 @@ fun AddQuoteBottomSheet(
 }
 
 
-fun Modifier.drawVerticalScrollbar(
-    state: LazyListState,
-    width: Dp = 4.dp,
-    color: Color = Color.Gray.copy(alpha = 0.5f)
-): Modifier = drawWithContent {
-    drawContent()
-
-    val firstVisibleElementIndex =
-        state.layoutInfo.visibleItemsInfo.firstOrNull()?.index ?: return@drawWithContent
-    val needScrollbar = state.layoutInfo.totalItemsCount > state.layoutInfo.visibleItemsInfo.size
-
-    if (needScrollbar) {
-        val elementHeight = size.height / state.layoutInfo.totalItemsCount
-        val scrollbarOffsetY = firstVisibleElementIndex * elementHeight
-        val scrollbarHeight = state.layoutInfo.visibleItemsInfo.size * elementHeight
-
-        drawRect(
-            color = color,
-            topLeft = Offset(size.width - width.toPx(), scrollbarOffsetY),
-            size = Size(width.toPx(), scrollbarHeight),
-        )
-    }
-}
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/boostcamp/and03/ui/component/CharacterCard.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/CharacterCard.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.and03.ui.screen.bookdetail.component
+package com.boostcamp.and03.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -28,8 +28,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.and03.R
-import com.boostcamp.and03.ui.component.IconBadge
-import com.boostcamp.and03.ui.component.LabelChip
+import com.boostcamp.and03.ui.screen.bookdetail.component.DropdownMenuContainer
 import com.boostcamp.and03.ui.theme.And03IconSize
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Radius

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -44,7 +43,7 @@ import coil.compose.AsyncImage
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03AppBar
 import com.boostcamp.and03.ui.component.EmptyDataScreen
-import com.boostcamp.and03.ui.screen.bookdetail.component.CharacterCard
+import com.boostcamp.and03.ui.component.CharacterCard
 import com.boostcamp.and03.ui.screen.bookdetail.component.DropdownMenuContainer
 import com.boostcamp.and03.ui.screen.bookdetail.component.MemoCard
 import com.boostcamp.and03.ui.component.QuoteCard

--- a/app/src/main/java/com/boostcamp/and03/ui/util/ScrollbarUtil.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/util/ScrollbarUtil.kt
@@ -1,0 +1,46 @@
+package com.boostcamp.and03.ui.util
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+fun Modifier.drawVerticalScrollbar(
+    state: LazyListState,
+    width: Dp = 4.dp,
+    color: Color = Color.Gray.copy(alpha = 0.5f)
+): Modifier = drawWithContent {
+    drawContent()
+
+    val layoutInfo = state.layoutInfo
+    val visibleItems = layoutInfo.visibleItemsInfo
+
+    if (visibleItems.isEmpty()) return@drawWithContent
+
+    val totalItemsCount = layoutInfo.totalItemsCount
+    val visibleItemsCount = visibleItems.size
+
+    if (totalItemsCount <= visibleItemsCount) return@drawWithContent
+
+    val firstVisibleIndex = visibleItems.first().index
+
+    val elementHeight = size.height / totalItemsCount
+    val scrollbarHeight = visibleItemsCount * elementHeight
+    val scrollbarOffsetY = firstVisibleIndex * elementHeight
+
+    drawRect(
+        color = color,
+        topLeft = Offset(
+            x = size.width - width.toPx(),
+            y = scrollbarOffsetY
+        ),
+        size = Size(
+            width = width.toPx(),
+            height = scrollbarHeight
+        )
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,4 +117,12 @@
     <string name="add_quote_bottom_sheet_new_sentence">새 문장 추가</string>
     <string name="add_quote_bottom_sheet_button_add">추가하기</string>
 
+    <!-- Add Node - Bottom Sheet -->
+    <string name="add_node_bottom_sheet_title">노드 추가</string>
+    <string name="add_node_bottom_sheet_info_title">등장인물을 선택해 노드를 추가해주세요.</string>
+    <string name="add_node_bottom_sheet_info_description">아직 등록하지 않았다면 새 등장인물을 추가할 수 있어요.</string>
+    <string name="add_node_bottom_sheet_search_placeholder">등장인물 이름을 검색하세요.</string>
+    <string name="add_node_bottom_sheet_new_character">새 등장인물 추가</string>
+    <string name="add_node_bottom_sheet_add_button">추가하기</string>
+
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈
- #이슈번호1: {이슈에 대한 간략한 설명}
- #이슈번호2: {이슈에 대한 간략한 설명}

## 📝작업 내용
> 기존에 있던 컴포넌트
  And03InfoSection , SearchTextField, CharacterCard, And03Button 을 사용해서 구현. 


## 🤔시행착오 및 고민
> CharacterCard ui 도 QuoteCard 처럼 more 버튼 대응이 필요할듯 (more 버튼 삭제?)

## 💬추가 작업 사항 
> 현재 node(character), quote ui 부분은 구현이 완료 / 화면 데이터 연결이 필요함(구현중) 

## 🖼️스크린샷 (선택)

<img width="178" height="390" alt="image" src="https://github.com/user-attachments/assets/a922a1f9-faf0-4693-b8f5-64aa663577f4" />

