### PR TITLE
메모 관계도 화면 구절 추가 바텀시트 및 다이얼로그 연동

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/ui/component/And03ActionDialog.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/And03ActionDialog.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,7 +36,9 @@ fun And03ActionDialog(
             color = And03Theme.colors.surface
         ) {
             Column(
-                modifier = modifier.padding(And03Padding.PADDING_L),
+                modifier = modifier
+                    .padding(And03Padding.PADDING_L)
+                    .verticalScroll(rememberScrollState()),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_L)
             ) {

--- a/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/EditableTextField.kt
@@ -49,9 +49,12 @@ fun EditableTextField(
             unfocusedTextColor = And03Theme.colors.onSurface,
             focusedContainerColor = And03Theme.colors.surface,
             unfocusedContainerColor = And03Theme.colors.surface,
-            focusedIndicatorColor = And03Theme.colors.outline,
+            focusedIndicatorColor = And03Theme.colors.primary,
             unfocusedIndicatorColor = And03Theme.colors.outline,
-            disabledIndicatorColor = And03Theme.colors.outline,
+            disabledIndicatorColor = And03Theme.colors.onSurfaceVariant,
+            focusedLabelColor = And03Theme.colors.primary,
+            unfocusedLabelColor = And03Theme.colors.onSurfaceVariant,
+            disabledLabelColor = And03Theme.colors.onSurfaceVariant,
         ),
     )
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/component/QuoteCard.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/QuoteCard.kt
@@ -48,7 +48,7 @@ fun QuoteCard(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = And03Padding.PADDING_XL),
+                    .padding(horizontal = And03Padding.PADDING_XL),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.Top
             ) {

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavHost.kt
@@ -73,8 +73,11 @@ fun MainNavHost(
                     memoId = memoId
                 )
             },
-            navigateToCanvas = { memoId ->
-                navigator.navigateToCanvas(memoId)
+            navigateToCanvas = { bookId, memoId ->
+                navigator.navigateToCanvas(
+                    bookId = bookId,
+                    memoId = memoId
+                )
             },
         )
 

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavigator.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/MainNavigator.kt
@@ -35,9 +35,15 @@ class MainNavigator(
         )
     }
 
-    fun navigateToCanvas(memoId: String) {
+    fun navigateToCanvas(
+        bookId: String,
+        memoId: String
+    ) {
         navController.navigate(
-            Route.CanvasMemo(memoId = memoId)
+            Route.CanvasMemo(
+                bookId = bookId,
+                memoId = memoId
+            )
         )
     }
 

--- a/app/src/main/java/com/boostcamp/and03/ui/navigation/Route.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/navigation/Route.kt
@@ -19,7 +19,10 @@ sealed interface Route {
     data class BookDetail(val bookId: String) : Route
 
     @Serializable
-    data class CanvasMemo(val memoId: String) : Route
+    data class CanvasMemo(
+        val bookId: String,
+        val memoId: String
+    ) : Route
 
     @Serializable
     data class CharacterForm(

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailAction.kt
@@ -38,5 +38,8 @@ sealed interface BookDetailAction {
         val memoId: String
     ): BookDetailAction
 
-    data class OnCanvasMemoClick(val memoId: String): BookDetailAction
+    data class OnCanvasMemoClick(
+        val bookId: String,
+        val memoId: String
+    ): BookDetailAction
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailEvent.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailEvent.kt
@@ -24,5 +24,8 @@ sealed interface BookDetailEvent {
         val memoId: String
     ) : BookDetailEvent
 
-    data class NavigateToCanvas(val memoId: String) : BookDetailEvent
+    data class NavigateToCanvas(
+        val bookId: String,
+        val memoId: String
+    ) : BookDetailEvent
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailNavGraph.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailNavGraph.kt
@@ -12,7 +12,7 @@ fun NavGraphBuilder.bookDetailNavGraph(
     navigateToQuoteForm: (bookId: String, quoteId: String) -> Unit,
     navigateToTextMemoForm: (bookId: String, memoId: String) -> Unit,
     navigateToCanvasMemoForm: (bookId: String, memoId: String) -> Unit,
-    navigateToCanvas: (String) -> Unit,
+    navigateToCanvas: (bookId: String, memoId: String) -> Unit,
 ) {
     composable<Route.BookDetail> {
         BookDetailRoute(

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailScreen.kt
@@ -69,7 +69,7 @@ fun BookDetailRoute(
     navigateToQuoteForm: (bookId: String, quoteId: String) -> Unit,
     navigateToTextMemoForm: (bookId: String, memoId: String) -> Unit,
     navigateToCanvasMemoForm: (bookId: String, memoId: String) -> Unit,
-    navigateToCanvas: (memoId: String) -> Unit,
+    navigateToCanvas: (bookId: String, memoId: String) -> Unit,
     viewModel: BookDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -107,7 +107,10 @@ fun BookDetailRoute(
             }
 
             is BookDetailEvent.NavigateToCanvas -> {
-                navigateToCanvas(event.memoId)
+                navigateToCanvas(
+                    event.bookId,
+                    event.memoId
+                )
             }
         }
     }
@@ -265,7 +268,12 @@ private fun BookDetailScreen(
                                 },
                                 onMemoClick = { memo ->
                                     if (memo.memoType == MemoType.CANVAS) {
-                                        onAction(BookDetailAction.OnCanvasMemoClick(memo.id))
+                                        onAction(
+                                            BookDetailAction.OnCanvasMemoClick(
+                                                uiState.bookId,
+                                                memo.id
+                                            )
+                                        )
                                     }
                                 },
                                 onDeleteMemoClick = { memoId ->

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/bookdetail/BookDetailViewModel.kt
@@ -125,7 +125,12 @@ class BookDetailViewModel @Inject constructor(
                 )
             )
 
-            is BookDetailAction.OnCanvasMemoClick -> _event.trySend(BookDetailEvent.NavigateToCanvas(action.memoId))
+            is BookDetailAction.OnCanvasMemoClick -> _event.trySend(
+                BookDetailEvent.NavigateToCanvas(
+                    action.bookId,
+                    action.memoId
+                )
+            )
         }
     }
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
@@ -4,19 +4,26 @@ import com.boostcamp.and03.ui.screen.canvasmemo.component.bottombar.MainBottomBa
 
 import androidx.compose.ui.geometry.Offset
 
-sealed class CanvasMemoAction {
-    data object ClickBack : CanvasMemoAction()
-    data object CloseRelationDialog : CanvasMemoAction()
-    data object CloseAddCharacterDialog : CanvasMemoAction()
+sealed interface CanvasMemoAction {
+
+    data object ClickBack : CanvasMemoAction
+
+    data object CloseRelationDialog : CanvasMemoAction
+
+    data object CloseAddCharacterDialog : CanvasMemoAction
+
+    data object CloseQuoteDialog : CanvasMemoAction
+
+    data object AddQuote : CanvasMemoAction
+
     data class OpenRelationDialog(
         val fromNodeId: String,
         val toNodeId: String
-    ) : CanvasMemoAction()
-    data class OnBottomBarClick(
-        val type: MainBottomBarType
-    ) : CanvasMemoAction()
+    ) : CanvasMemoAction
 
-    data class MoveNode(val nodeId: String, val newOffset: Offset) : CanvasMemoAction()
-    data class ConnectNodes(val fromId: String, val toId: String, val name: String) : CanvasMemoAction()
+    data class OnBottomBarClick(val type: MainBottomBarType) : CanvasMemoAction
 
+    data class MoveNode(val nodeId: String, val newOffset: Offset) : CanvasMemoAction
+
+    data class ConnectNodes(val fromId: String, val toId: String, val name: String) : CanvasMemoAction
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
@@ -16,9 +16,11 @@ sealed interface CanvasMemoAction {
 
     data object CloseQuoteDialog : CanvasMemoAction
 
-    data object AddQuote : CanvasMemoAction
+    data object AddQuoteItem : CanvasMemoAction
 
     data class SearchQuote(val query: String) : CanvasMemoAction
+
+    data object AddNewQuote : CanvasMemoAction
 
     data class OpenRelationDialog(
         val fromNodeId: String,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
@@ -8,6 +8,8 @@ sealed interface CanvasMemoAction {
 
     data object ClickBack : CanvasMemoAction
 
+    data object CloseBottomSheet : CanvasMemoAction
+
     data object CloseRelationDialog : CanvasMemoAction
 
     data object CloseAddCharacterDialog : CanvasMemoAction
@@ -15,6 +17,8 @@ sealed interface CanvasMemoAction {
     data object CloseQuoteDialog : CanvasMemoAction
 
     data object AddQuote : CanvasMemoAction
+
+    data class SearchQuote(val query: String) : CanvasMemoAction
 
     data class OpenRelationDialog(
         val fromNodeId: String,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoBottomSheetType.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoBottomSheetType.kt
@@ -1,0 +1,8 @@
+package com.boostcamp.and03.ui.screen.canvasmemo
+
+sealed interface CanvasMemoBottomSheetType {
+
+    data object AddCharacter : CanvasMemoBottomSheetType
+
+    data object AddQuote : CanvasMemoBottomSheetType
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -47,7 +47,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03AppBar
-import com.boostcamp.and03.ui.component.NodeItem
+import com.boostcamp.and03.ui.screen.canvasmemo.component.NodeItem
 import com.boostcamp.and03.ui.screen.canvasmemo.component.ToolAction
 import com.boostcamp.and03.ui.screen.canvasmemo.component.ToolExpandableButton
 import com.boostcamp.and03.ui.screen.canvasmemo.component.bottombar.MainBottomBar

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -47,6 +47,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03AppBar
+import com.boostcamp.and03.ui.screen.canvasmemo.component.AddQuoteBottomSheet
+import com.boostcamp.and03.ui.screen.canvasmemo.component.AddQuoteDialog
 import com.boostcamp.and03.ui.screen.canvasmemo.component.NodeItem
 import com.boostcamp.and03.ui.screen.canvasmemo.component.ToolAction
 import com.boostcamp.and03.ui.screen.canvasmemo.component.ToolExpandableButton
@@ -115,21 +117,20 @@ private fun CanvasMemoScreen(
     Scaffold(
         topBar = {
             And03AppBar(
-                title = "임시 제목",
+                title = stringResource(R.string.canvas_memo_top_bar_title),
                 onBackClick = { onAction(CanvasMemoAction.ClickBack) }
             ) {
                 IconButton(onClick = {}) {
                     Icon(
                         painter = painterResource(R.drawable.ic_more_vert_filled),
                         contentDescription = stringResource(
-                            R.string.content_description_more_button
+                            id = R.string.content_description_more_button
                         )
                     )
                 }
             }
         }
     ) { innerPadding ->
-
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -158,7 +159,6 @@ private fun CanvasMemoScreen(
                             transformOrigin = TransformOrigin(0f, 0f)
                         }
                 ) {
-
                     Arrows(
                         arrows = uiState.edges,
                         items = uiState.nodes,
@@ -215,6 +215,7 @@ private fun CanvasMemoScreen(
                         }
                     }
                 }
+
                 Card(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
@@ -236,7 +237,19 @@ private fun CanvasMemoScreen(
                 }
             }
 
-//
+            // BottomSheet 표시
+            if (uiState.isAddCharacterBottomSheetVisible) {
+                // TODO: 등장인물 추가 바텀시트 표시
+            }
+
+            if (uiState.isQuoteBottomSheetVisible) {
+                AddQuoteBottomSheet(
+                    quotes = uiState.quotes,
+                    onAddClick = { onAction(CanvasMemoAction.AddQuote) },
+                )
+            }
+
+            // Dialog 표시
 //                if (uiState.isRelationDialogVisible) {
 //                    RelationEditorDialog(
 //                        relationNameState = uiState.relationNameState,
@@ -260,6 +273,16 @@ private fun CanvasMemoScreen(
 //                    )
 //                }
 //            }
+
+            if (uiState.isQuoteDialogVisible) {
+                AddQuoteDialog(
+                    quoteState = uiState.quoteState,
+                    pageState = uiState.pageState,
+                    enabled = uiState.characterNameState.text.isNotBlank() && uiState.quoteState.text.isNotBlank(),
+                    onDismiss = { onAction(CanvasMemoAction.CloseQuoteDialog) },
+                    onConfirm = { /* TODO: onAction(CanvasMemoAction.AddQuote) 구현 */ }
+                )
+            }
 
             ToolExpandableButton(
                 modifier = Modifier

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -317,7 +316,7 @@ private fun CanvasMemoScreen(
                 AddQuoteDialog(
                     quoteState = uiState.quoteState,
                     pageState = uiState.pageState,
-                    enabled = uiState.characterNameState.text.isNotBlank() && uiState.quoteState.text.isNotBlank(),
+                    enabled = uiState.quoteState.text.isNotBlank() && uiState.pageState.text.isNotBlank(),
                     onDismiss = { onAction(CanvasMemoAction.CloseQuoteDialog) },
                     onConfirm = { onAction(CanvasMemoAction.AddQuoteItem) }
                 )

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -62,6 +62,7 @@ import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
 import com.boostcamp.and03.ui.theme.CanvasMemoColors
+import com.boostcamp.and03.ui.util.collectWithLifecycle
 import kotlin.math.max
 import kotlin.math.min
 
@@ -79,11 +80,9 @@ fun CanvasMemoRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        viewModel.event.collect { event ->
-            when (event) {
-                is CanvasMemoEvent.NavToBack -> navigateToBack()
-            }
+    viewModel.event.collectWithLifecycle { event ->
+        when (event) {
+            is CanvasMemoEvent.NavToBack -> navigateToBack()
         }
     }
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -112,6 +112,14 @@ private fun CanvasMemoScreen(
         skipPartiallyExpanded = true
     )
 
+    LaunchedEffect(uiState.bottomSheetType) {
+        if (uiState.bottomSheetType != null) {
+            sheetState.show()
+        } else {
+            sheetState.hide()
+        }
+    }
+
     fun clampOffset(
         newOffset: Offset,
     ): Offset {
@@ -266,8 +274,8 @@ private fun CanvasMemoScreen(
                         CanvasMemoBottomSheetType.AddQuote -> {
                             AddQuoteBottomSheet(
                                 quotes = uiState.quotes,
-                                onAddClick = { onAction(CanvasMemoAction.AddQuote) },
-                                onNewSentenceClick = { onAction(CanvasMemoAction.AddQuote) },
+                                onAddClick = { onAction(CanvasMemoAction.AddQuoteItem) },
+                                onNewSentenceClick = { onAction(CanvasMemoAction.AddNewQuote) },
                                 onSearch = { /* TODO: onAction(CanvasMemoAction.SearchQuote()) 구현 */ }
                             )
                         }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -65,6 +65,13 @@ import com.boostcamp.and03.ui.theme.CanvasMemoColors
 import kotlin.math.max
 import kotlin.math.min
 
+private object CanvasMemoScreenValues {
+    val CANVAS_SIZE = 2000.dp
+    val MIN_SCALE = 0.5f
+    val MAX_SCALE = 2f
+    val MAX_OFFSET_RANGE = 1000f
+}
+
 @Composable
 fun CanvasMemoRoute(
     navigateToBack: () -> Unit,
@@ -93,20 +100,13 @@ private fun CanvasMemoScreen(
 ) {
     var scale by remember { mutableFloatStateOf(1f) }
     var panOffset by remember { mutableStateOf(Offset(0f, 0f)) }
-
-    val canvasSize = 2000.dp
-    val minScale = 0.5f
-    val maxScale = 2f
-
-    val maxOffsetRange = 1000f
-
     var nodeSizes by remember { mutableStateOf<Map<String, IntSize>>(emptyMap()) }
 
     fun clampOffset(
         newOffset: Offset,
     ): Offset {
-        val maxOffset = maxOffsetRange
-        val minOffset = -maxOffsetRange
+        val maxOffset = CanvasMemoScreenValues.MAX_OFFSET_RANGE
+        val minOffset = -CanvasMemoScreenValues.MAX_OFFSET_RANGE
 
         return Offset(
             x = max(minOffset, min(maxOffset, newOffset.x)),
@@ -141,7 +141,11 @@ private fun CanvasMemoScreen(
                     .fillMaxSize()
                     .pointerInput(Unit) {
                         detectTransformGestures { _, pan, zoom, _ ->
-                            val newScale = (scale * zoom).coerceIn(minScale, maxScale)
+                            val newScale = (scale * zoom)
+                                .coerceIn(
+                                    CanvasMemoScreenValues.MIN_SCALE,
+                                    CanvasMemoScreenValues.MAX_SCALE
+                                )
 
                             scale = newScale
                             panOffset = clampOffset(panOffset + pan)
@@ -150,7 +154,7 @@ private fun CanvasMemoScreen(
             ) {
                 Box(
                     modifier = Modifier
-                        .size(canvasSize)
+                        .size(CanvasMemoScreenValues.CANVAS_SIZE)
                         .graphicsLayer {
                             scaleX = scale
                             scaleY = scale
@@ -296,14 +300,22 @@ private fun CanvasMemoScreen(
                         iconRes = R.drawable.ic_add_filled,
                         contentDescription = stringResource(R.string.tool_ic_content_desc_zoom_in),
                         onClick = {
-                            scale = (scale * 1.2f).coerceIn(minScale, maxScale)
+                            scale = (scale * 1.2f)
+                                .coerceIn(
+                                    CanvasMemoScreenValues.MIN_SCALE,
+                                    CanvasMemoScreenValues.MAX_SCALE
+                                )
                         }
                     ),
                     ToolAction(
                         iconRes = R.drawable.ic_remove_filled,
                         contentDescription = stringResource(R.string.tool_ic_content_desc_zoom_out),
                         onClick = {
-                            scale = (scale / 1.2f).coerceIn(minScale, maxScale)
+                            scale = (scale / 1.2f)
+                                .coerceIn(
+                                    CanvasMemoScreenValues.MIN_SCALE,
+                                    CanvasMemoScreenValues.MAX_SCALE
+                                )
                         }
                     ),
                     ToolAction(

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -18,11 +18,14 @@ import androidx.compose.material.icons.filled.FormatQuote
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -92,6 +95,7 @@ fun CanvasMemoRoute(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun CanvasMemoScreen(
     uiState: CanvasMemoUiState,
@@ -100,6 +104,10 @@ private fun CanvasMemoScreen(
     var scale by remember { mutableFloatStateOf(1f) }
     var panOffset by remember { mutableStateOf(Offset(0f, 0f)) }
     var nodeSizes by remember { mutableStateOf<Map<String, IntSize>>(emptyMap()) }
+
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
 
     fun clampOffset(
         newOffset: Offset,
@@ -240,16 +248,26 @@ private fun CanvasMemoScreen(
                 }
             }
 
-            // BottomSheet 표시
-            if (uiState.isAddCharacterBottomSheetVisible) {
-                // TODO: 등장인물 추가 바텀시트 표시
-            }
+            uiState.bottomSheetType?.let { sheetType ->
+                ModalBottomSheet(
+                    onDismissRequest = { onAction(CanvasMemoAction.CloseBottomSheet) },
+                    sheetState = sheetState
+                ) {
+                    when (sheetType) {
+                        CanvasMemoBottomSheetType.AddCharacter -> {
+                            // TODO: 등장인물 노드 추가 바텀 시트 출력
+                        }
 
-            if (uiState.isQuoteBottomSheetVisible) {
-                AddQuoteBottomSheet(
-                    quotes = uiState.quotes,
-                    onAddClick = { onAction(CanvasMemoAction.AddQuote) },
-                )
+                        CanvasMemoBottomSheetType.AddQuote -> {
+                            AddQuoteBottomSheet(
+                                quotes = uiState.quotes,
+                                onAddClick = { onAction(CanvasMemoAction.AddQuote) },
+                                onNewSentenceClick = { onAction(CanvasMemoAction.AddQuote) },
+                                onSearch = { /* TODO: onAction(CanvasMemoAction.SearchQuote()) 구현 */ }
+                            )
+                        }
+                    }
+                }
             }
 
             // Dialog 표시

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -8,10 +8,13 @@ import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FormatQuote
@@ -250,8 +253,10 @@ private fun CanvasMemoScreen(
 
             uiState.bottomSheetType?.let { sheetType ->
                 ModalBottomSheet(
+                    modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing),
                     onDismissRequest = { onAction(CanvasMemoAction.CloseBottomSheet) },
-                    sheetState = sheetState
+                    sheetState = sheetState,
+                    containerColor = And03Theme.colors.background
                 ) {
                     when (sheetType) {
                         CanvasMemoBottomSheetType.AddCharacter -> {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
@@ -1,20 +1,38 @@
 package com.boostcamp.and03.ui.screen.canvasmemo
 
 import androidx.compose.foundation.text.input.TextFieldState
+import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
+import com.boostcamp.and03.ui.screen.bookdetail.model.QuoteUiModel
 import com.boostcamp.and03.ui.screen.canvasmemo.model.EdgeUiModel
 import com.boostcamp.and03.ui.screen.canvasmemo.component.bottombar.MainBottomBarType
 import com.boostcamp.and03.ui.screen.canvasmemo.model.MemoNodeUiModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 data class CanvasMemoUiState(
     val nodes: Map<String, MemoNodeUiModel> = emptyMap(),
     val edges: List<EdgeUiModel> = emptyList(),
+
     val relationSelection: RelationSelection? = null,
     val relationNameState: TextFieldState = TextFieldState(),
-    val isRelationDialogVisible: Boolean = false,
+
+    val isAddCharacterBottomSheetVisible: Boolean = false,
+    val isQuoteBottomSheetVisible: Boolean = false,
+
     val isAddCharacterDialogVisible: Boolean = false,
+    val isRelationDialogVisible: Boolean = false,
+    val isQuoteDialogVisible: Boolean = false,
+
     val characterNameState: TextFieldState = TextFieldState(),
     val characterDescState: TextFieldState = TextFieldState(),
+
+    val quoteState: TextFieldState = TextFieldState(),
+    val pageState: TextFieldState = TextFieldState(),
+
     val selectedBottomBarType: MainBottomBarType = MainBottomBarType.NODE, // 하단 메인 바텀바 상태 기본값은 노드로 설정함
+
+    val characters: ImmutableList<CharacterUiModel> = persistentListOf(),
+    val quotes: ImmutableList<QuoteUiModel> = persistentListOf(),
 )
 
 data class RelationSelection(

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
@@ -16,8 +16,7 @@ data class CanvasMemoUiState(
     val relationSelection: RelationSelection? = null,
     val relationNameState: TextFieldState = TextFieldState(),
 
-    val isAddCharacterBottomSheetVisible: Boolean = false,
-    val isQuoteBottomSheetVisible: Boolean = false,
+    val bottomSheetType: CanvasMemoBottomSheetType? = null,
 
     val isAddCharacterDialogVisible: Boolean = false,
     val isRelationDialogVisible: Boolean = false,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
@@ -18,6 +18,9 @@ data class CanvasMemoUiState(
 
     val bottomSheetType: CanvasMemoBottomSheetType? = null,
 
+    val isAddingCharacter: Boolean = false,
+    val isAddingQuote: Boolean = false,
+
     val isAddCharacterDialogVisible: Boolean = false,
     val isRelationDialogVisible: Boolean = false,
     val isQuoteDialogVisible: Boolean = false,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
@@ -34,7 +34,7 @@ data class CanvasMemoUiState(
     val selectedBottomBarType: MainBottomBarType = MainBottomBarType.NODE, // 하단 메인 바텀바 상태 기본값은 노드로 설정함
 
     val characters: ImmutableList<CharacterUiModel> = persistentListOf(),
-    val quotes: ImmutableList<QuoteUiModel> = persistentListOf(),
+    val quotes: ImmutableList<QuoteUiModel> = persistentListOf()
 )
 
 data class RelationSelection(

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.toRoute
 import com.boostcamp.and03.data.repository.book_storage.BookStorageRepository
 import com.boostcamp.and03.domain.editor.CanvasMemoEditor
@@ -125,9 +124,11 @@ class CanvasMemoViewModel @Inject constructor(
 
             CanvasMemoAction.CloseQuoteDialog -> handleCloseQuoteDialog()
 
-            CanvasMemoAction.AddQuote -> handleAddQuote()
+            CanvasMemoAction.AddQuoteItem -> handleAddQuote()
 
             is CanvasMemoAction.SearchQuote -> handleSearchQuote(action)
+
+            CanvasMemoAction.AddNewQuote -> handleAddNewQuote()
 
             is CanvasMemoAction.MoveNode -> handleMoveNode(action)
 
@@ -192,6 +193,17 @@ class CanvasMemoViewModel @Inject constructor(
 
     private fun handleSearchQuote(action: CanvasMemoAction.SearchQuote) {
         // TODO: 구절 검색 동작 연동
+    }
+
+    private fun handleAddNewQuote() {
+        _uiState.update {
+            it.copy(
+                isQuoteDialogVisible = true,
+                bottomSheetType = null,
+                quoteState = TextFieldState(),
+                pageState = TextFieldState()
+            )
+        }
     }
 
     private fun handleMoveNode(action: CanvasMemoAction.MoveNode) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
@@ -188,7 +188,11 @@ class CanvasMemoViewModel @Inject constructor(
     }
 
     private fun handleAddQuote() {
-        // TODO: 새로운 구절 추가 동작 연동
+        _uiState.update {
+            it.copy(
+                bottomSheetType = null
+            )
+        }
     }
 
     private fun handleSearchQuote(action: CanvasMemoAction.SearchQuote) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
@@ -14,6 +14,7 @@ import com.boostcamp.and03.ui.navigation.Route
 import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
 import com.boostcamp.and03.ui.screen.bookdetail.model.QuoteUiModel
 import com.boostcamp.and03.ui.screen.bookdetail.model.toUiModel
+import com.boostcamp.and03.ui.screen.canvasmemo.component.bottombar.MainBottomBarType
 import com.boostcamp.and03.ui.screen.canvasmemo.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
@@ -114,6 +115,8 @@ class CanvasMemoViewModel @Inject constructor(
         when (action) {
             CanvasMemoAction.ClickBack -> handleClickBack()
 
+            CanvasMemoAction.CloseBottomSheet -> handleCloseBottomSheet()
+
             CanvasMemoAction.CloseRelationDialog -> handleCloseRelationDialog()
 
             is CanvasMemoAction.OpenRelationDialog -> handleOpenRelationDialog(action)
@@ -123,6 +126,8 @@ class CanvasMemoViewModel @Inject constructor(
             CanvasMemoAction.CloseQuoteDialog -> handleCloseQuoteDialog()
 
             CanvasMemoAction.AddQuote -> handleAddQuote()
+
+            is CanvasMemoAction.SearchQuote -> handleSearchQuote(action)
 
             is CanvasMemoAction.MoveNode -> handleMoveNode(action)
 
@@ -134,6 +139,10 @@ class CanvasMemoViewModel @Inject constructor(
 
     private fun handleClickBack() {
         _event.trySend(CanvasMemoEvent.NavToBack)
+    }
+
+    private fun handleCloseBottomSheet() {
+        _uiState.update { it.copy(bottomSheetType = null) }
     }
 
     private fun handleCloseRelationDialog() {
@@ -181,6 +190,10 @@ class CanvasMemoViewModel @Inject constructor(
         // TODO: 새로운 구절 추가 동작 연동
     }
 
+    private fun handleSearchQuote(action: CanvasMemoAction.SearchQuote) {
+        // TODO: 구절 검색 동작 연동
+    }
+
     private fun handleMoveNode(action: CanvasMemoAction.MoveNode) {
         val editor = CanvasMemoEditor(getCurrentGraph())
         val updatedGraph = editor.moveNode(action.nodeId, action.newOffset)
@@ -208,9 +221,16 @@ class CanvasMemoViewModel @Inject constructor(
     }
 
     private fun handleBottomBarClick(action: CanvasMemoAction.OnBottomBarClick) {
+        val sheetType = when (action.type) {
+            MainBottomBarType.NODE -> CanvasMemoBottomSheetType.AddCharacter
+            MainBottomBarType.QUOTE -> CanvasMemoBottomSheetType.AddQuote
+            else -> null
+        }
+
         _uiState.update {
             it.copy(
-                selectedBottomBarType = action.type
+                selectedBottomBarType = action.type,
+                bottomSheetType = sheetType
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
@@ -56,8 +56,8 @@ fun AddQuoteBottomSheet(
     onAddClick: () -> Unit,
     onNewSentenceClick: () -> Unit,
     onSearch: (String) -> Unit,
-    isAdding: Boolean = false,
     modifier: Modifier = Modifier,
+    isAdding: Boolean = false,
 ) {
     val searchState = rememberTextFieldState()
     val listState = rememberLazyListState()

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
@@ -29,7 +29,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -71,21 +74,12 @@ fun AddQuoteBottomSheet(
                     topEnd = And03Radius.RADIUS_L
                 )
             )
-            .padding(horizontal = And03Padding.PADDING_L, vertical = And03Padding.PADDING_M),
+            .padding(
+                horizontal = And03Padding.PADDING_L,
+                vertical = And03Padding.PADDING_M
+            ),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Box(
-            modifier = Modifier
-                .width(40.dp)
-                .height(4.dp)
-                .background(
-                    And03Theme.colors.outlineVariant,
-                    RoundedCornerShape(And03Radius.RADIUS_S)
-                )
-        )
-
-        Spacer(modifier = Modifier.height(And03Spacing.SPACE_L))
-
         Text(
             text = stringResource(R.string.add_quote_bottom_sheet_title),
             style = And03Theme.typography.titleMedium,
@@ -114,6 +108,7 @@ fun AddQuoteBottomSheet(
             state = listState,
             modifier = Modifier
                 .weight(1f, fill = false)
+                .nestedScroll(rememberNestedScrollInteropConnection())
                 .drawVerticalScrollbar(listState, color = And03Theme.colors.outlineVariant),
             verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_S),
             contentPadding = PaddingValues(bottom = And03Padding.PADDING_M)
@@ -135,7 +130,13 @@ fun AddQuoteBottomSheet(
                 ) {
                     QuoteCard(
                         quote = quote,
-                        onClick = { selectedQuoteId = quote.id },
+                        onClick = {
+                            if (selectedQuoteId == null || selectedQuoteId != quote.id) {
+                                selectedQuoteId = quote.id
+                            } else {
+                                selectedQuoteId = null
+                            }
+                        },
                     )
                 }
             }
@@ -150,7 +151,9 @@ fun AddQuoteBottomSheet(
                 contentDescription = null,
                 modifier = Modifier.size(And03IconSize.ICON_SIZE_S)
             )
+
             Spacer(modifier = Modifier.width(And03Spacing.SPACE_XS))
+
             Text(
                 text = stringResource(R.string.add_quote_bottom_sheet_new_sentence),
                 style = And03Theme.typography.labelLarge
@@ -163,12 +166,11 @@ fun AddQuoteBottomSheet(
             variant = ButtonVariant.Primary,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(And03ComponentSize.BUTTON_HEIGHT_L)
+                .height(And03ComponentSize.BUTTON_HEIGHT_L),
+            enabled = selectedQuoteId != null
         )
     }
 }
-
-
 
 @Preview(showBackground = true)
 @Composable
@@ -181,6 +183,7 @@ private fun AddQuoteBottomSheetPreview() {
             date = "2026.01.14"
         )
     }
+
     And03Theme {
         AddQuoteBottomSheet(quotes = dummyQuotes)
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
@@ -29,13 +29,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03Button
 import com.boostcamp.and03.ui.component.And03InfoSection
@@ -58,6 +56,7 @@ fun AddQuoteBottomSheet(
     onAddClick: () -> Unit,
     onNewSentenceClick: () -> Unit,
     onSearch: (String) -> Unit,
+    isAdding: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val searchState = rememberTextFieldState()
@@ -161,13 +160,17 @@ fun AddQuoteBottomSheet(
         }
 
         And03Button(
-            text = stringResource(R.string.add_quote_bottom_sheet_button_add),
+            text = if (!isAdding) {
+                stringResource(R.string.add_quote_bottom_sheet_button_add)
+            } else {
+                stringResource(R.string.add_quote_bottom_sheet_button_adding)
+            },
             onClick = onAddClick,
             variant = ButtonVariant.Primary,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(And03ComponentSize.BUTTON_HEIGHT_L),
-            enabled = selectedQuoteId != null
+            enabled = selectedQuoteId != null && !isAdding
         )
     }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
@@ -107,7 +107,6 @@ fun AddQuoteBottomSheet(
             state = listState,
             modifier = Modifier
                 .weight(1f, fill = false)
-                .nestedScroll(rememberNestedScrollInteropConnection())
                 .drawVerticalScrollbar(listState, color = And03Theme.colors.outlineVariant),
             verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_S),
             contentPadding = PaddingValues(bottom = And03Padding.PADDING_M)

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteBottomSheet.kt
@@ -54,11 +54,11 @@ import com.boostcamp.and03.ui.util.drawVerticalScrollbar
 
 @Composable
 fun AddQuoteBottomSheet(
+    quotes: List<QuoteUiModel>,
+    onAddClick: () -> Unit,
+    onNewSentenceClick: () -> Unit,
+    onSearch: (String) -> Unit,
     modifier: Modifier = Modifier,
-    quotes: List<QuoteUiModel> = emptyList(),
-    onAddClick: () -> Unit = {},
-    onNewSentenceClick: () -> Unit = {},
-    onSearch: (String) -> Unit = {},
 ) {
     val searchState = rememberTextFieldState()
     val listState = rememberLazyListState()
@@ -185,6 +185,11 @@ private fun AddQuoteBottomSheetPreview() {
     }
 
     And03Theme {
-        AddQuoteBottomSheet(quotes = dummyQuotes)
+        AddQuoteBottomSheet(
+            quotes = dummyQuotes,
+            onAddClick = {},
+            onNewSentenceClick = {},
+            onSearch = {}
+        )
     }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteDialog.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteDialog.kt
@@ -1,0 +1,137 @@
+package com.boostcamp.and03.ui.screen.canvasmemo.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import com.boostcamp.and03.R
+import com.boostcamp.and03.ui.component.AddTextByImageButton
+import com.boostcamp.and03.ui.component.And03ActionDialog
+import com.boostcamp.and03.ui.component.EditableTextField
+import com.boostcamp.and03.ui.component.LabelAndEditableTextField
+import com.boostcamp.and03.ui.component.OCRBottomSheet
+import com.boostcamp.and03.ui.screen.canvasmemo.component.AddQuoteDialogValues.MAX_CHARACTER_COUNT
+import com.boostcamp.and03.ui.theme.And03ComponentSize
+import com.boostcamp.and03.ui.theme.And03Spacing
+import com.boostcamp.and03.ui.theme.And03Theme
+
+private object AddQuoteDialogValues {
+    const val MAX_CHARACTER_COUNT = 500
+}
+
+@Composable
+fun AddQuoteDialog(
+    quoteState: TextFieldState,
+    pageState: TextFieldState,
+    enabled: Boolean = false,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    var isOCRBottomSheetVisible by remember { mutableStateOf(false) }
+
+    And03ActionDialog(
+        title = stringResource(id = R.string.add_quote_title),
+        dismissText = stringResource(id = R.string.common_cancel),
+        confirmText = stringResource(id = R.string.common_save),
+        onDismiss = onDismiss,
+        onConfirm = onConfirm,
+        enabled = enabled,
+        content = {
+            QuoteInputSection(
+                quoteState = quoteState,
+                onAddByImageClick = { isOCRBottomSheetVisible = true }
+            )
+
+            if (isOCRBottomSheetVisible) {
+                OCRBottomSheet(
+                    onDismiss = { isOCRBottomSheetVisible = false },
+                    onCameraClick = { /* TODO: 텍스트 가져오기 기능 구현 */ },
+                    onGalleryClick = { /* TODO: 사진 촬영 기능 구현 */ }
+                )
+            }
+
+            LabelAndEditableTextField(
+                labelRes = R.string.add_quote_page_label,
+                state = pageState,
+                placeholderRes = R.string.add_quote_page_hint,
+                onSubmit = {},
+                imeAction = ImeAction.Done,
+                keyboardType = KeyboardType.Number,
+                lineLimits = 1
+            )
+        }
+    )
+}
+
+@Composable
+private fun QuoteInputSection(
+    quoteState: TextFieldState,
+    onAddByImageClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_S)
+    ) {
+        Row(
+            verticalAlignment = Alignment.Bottom
+        ) {
+            Text(
+                text = stringResource(R.string.add_quote_sentence_label),
+                style = And03Theme.typography.labelLarge
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            AddTextByImageButton(onAddByImageClick = onAddByImageClick)
+        }
+
+        EditableTextField(
+            state = quoteState,
+            placeholderRes = R.string.add_quote_sentence_hint,
+            onSubmit = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(And03ComponentSize.TEXT_FIELD_HEIGHT_L)
+        )
+
+        Text(
+            text = stringResource(
+                id = R.string.add_quote_text_count,
+                quoteState.text.length,
+                MAX_CHARACTER_COUNT
+            ),
+            modifier = Modifier.align(Alignment.End),
+            style = And03Theme.typography.bodySmall,
+            color = And03Theme.colors.onSurfaceVariant
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddQuoteDialogPreview() {
+    And03Theme {
+        AddQuoteDialog(
+            quoteState = TextFieldState(),
+            pageState = TextFieldState(),
+            onDismiss = {},
+            onConfirm = {}
+        )
+    }
+}

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteDialog.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteDialog.kt
@@ -25,7 +25,6 @@ import com.boostcamp.and03.ui.component.And03ActionDialog
 import com.boostcamp.and03.ui.component.EditableTextField
 import com.boostcamp.and03.ui.component.LabelAndEditableTextField
 import com.boostcamp.and03.ui.component.OCRBottomSheet
-import com.boostcamp.and03.ui.screen.canvasmemo.component.AddQuoteDialogValues.MAX_CHARACTER_COUNT
 import com.boostcamp.and03.ui.theme.And03ComponentSize
 import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
@@ -107,14 +106,15 @@ private fun QuoteInputSection(
             onSubmit = {},
             modifier = Modifier
                 .fillMaxWidth()
-                .height(And03ComponentSize.TEXT_FIELD_HEIGHT_L)
+                .height(And03ComponentSize.TEXT_FIELD_HEIGHT_L),
+            maxCharacterCount = AddQuoteDialogValues.MAX_CHARACTER_COUNT
         )
 
         Text(
             text = stringResource(
                 id = R.string.add_quote_text_count,
                 quoteState.text.length,
-                MAX_CHARACTER_COUNT
+                AddQuoteDialogValues.MAX_CHARACTER_COUNT
             ),
             modifier = Modifier.align(Alignment.End),
             style = And03Theme.typography.bodySmall,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteDialog.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/AddQuoteDialog.kt
@@ -70,8 +70,7 @@ fun AddQuoteDialog(
                 placeholderRes = R.string.add_quote_page_hint,
                 onSubmit = {},
                 imeAction = ImeAction.Done,
-                keyboardType = KeyboardType.Number,
-                lineLimits = 1
+                keyboardType = KeyboardType.Number
             )
         }
     )
@@ -107,7 +106,8 @@ private fun QuoteInputSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(And03ComponentSize.TEXT_FIELD_HEIGHT_L),
-            maxCharacterCount = AddQuoteDialogValues.MAX_CHARACTER_COUNT
+            maxCharacterCount = AddQuoteDialogValues.MAX_CHARACTER_COUNT,
+            lineLimits = AddQuoteDialogValues.MAX_CHARACTER_COUNT
         )
 
         Text(

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.and03.ui.component
+package com.boostcamp.and03.ui.screen.canvasmemo.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.and03.R
+import com.boostcamp.and03.ui.component.IconBadge
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/PagelistScroll.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/PagelistScroll.kt
@@ -27,7 +27,6 @@ import com.boostcamp.and03.ui.theme.And03Theme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import com.boostcamp.and03.R
-import com.boostcamp.and03.ui.util.drawVerticalScrollbar
 
 @Composable
 fun PagelistScroll(
@@ -74,12 +73,12 @@ private fun PagelistItem(
 ) {
     val pageText = if (startPage == endPage) {
         stringResource(
-            id = R.string.canvas_memo_editor_page_list_scroll_single_page,
+            id = R.string.canvas_memo_page_list_scroll_single_page,
             startPage
         )
     } else {
         stringResource(
-            id = R.string.canvas_memo_editor_page_list_scroll_page_range,
+            id = R.string.canvas_memo_page_list_scroll_page_range,
             startPage,
             endPage
         )

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/QuoteItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/QuoteItem.kt
@@ -1,4 +1,4 @@
-package com.boostcamp.and03.ui.component
+package com.boostcamp.and03.ui.screen.canvasmemo.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/bottombar/MainBottomBar.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/bottombar/MainBottomBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.boostcamp.and03.ui.theme.And03ComponentSize
@@ -50,21 +51,24 @@ fun MainBottomBar(
 private fun MainBottomBarButton(
     item: MainBottomBarItem,
     isSelected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.clickable(onClick = onClick)
+        modifier = modifier
     ) {
         Box(
             modifier = Modifier
                 .size(And03ComponentSize.BOTTOM_BAR_ITEM_SIZE)
+                .clip(RoundedCornerShape(And03Radius.RADIUS_L))
                 .background(
                     color = item.backgroundColor.copy(
                         alpha = if (isSelected) 1f else 0.6f
                     ),
                     shape = RoundedCornerShape(And03Radius.RADIUS_L)
-                ),
+                )
+                .clickable(onClick = onClick),
             contentAlignment = Alignment.Center
         ) {
             Icon(
@@ -84,6 +88,7 @@ private fun MainBottomBarButton(
         )
     }
 }
+
 @Preview(showBackground = true)
 @Composable
 private fun MainBottomBarPreview() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,8 +93,9 @@
     <string name="add_character_dialog_name_placeholder">이름을 입력하세요.</string>
     <string name="add_character_dialog_desc_label">설명</string>
     <string name="add_character_dialog_desc_placeholder">설명을 입력하세요</string>
-    <string name="canvas_memo_editor_page_list_scroll_page_range">p.%1$d~%2$d</string>
-    <string name="canvas_memo_editor_page_list_scroll_single_page">p.%1$d</string>
+    <string name="canvas_memo_page_list_scroll_page_range">p.%1$d~%2$d</string>
+    <string name="canvas_memo_page_list_scroll_single_page">p.%1$d</string>
+    <string name="canvas_memo_top_bar_title">캔버스 메모</string>
 
     <!-- Content Description -->
     <string name="content_description_go_back">뒤로 가기</string>
@@ -109,16 +110,12 @@
 
     <!-- Add Quote -->
     <string name="add_quote_title">인상 깊은 구절 추가</string>
-
     <string name="add_quote_info_title">인상 깊은 구절을 기록해보세요</string>
     <string name="add_quote_info_description">책이나 영화, 일상에서 마음에 든 문장을 저장할 수 있습니다.</string>
-
     <string name="add_quote_sentence_label">구절 *</string>
     <string name="add_quote_sentence_hint">인상깊은 구절을 입력하세요</string>
     <string name="add_quote_add_by_image">이미지로 추가</string>
-
     <string name="add_quote_text_count">%1$d/%2$d</string>
-
     <string name="add_quote_page_label">페이지 *</string>
     <string name="add_quote_page_hint">구절이 기록된 페이지를 입력하세요</string>
 
@@ -143,6 +140,7 @@
     <string name="canvas_bottom_bar_relation">관계</string>
     <string name="canvas_bottom_bar_quote">구절</string>
     <string name="canvas_bottom_bar_delete">삭제</string>
+
     <!-- 등장인물 추가 화면 -->
     <string name="character_form_title">등장인물 추가</string>
     <string name="character_form_name">이름 *</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="add_quote_bottom_sheet_search_placeholder">인상깊은 문장 또는 페이지를 입력하세요.</string>
     <string name="add_quote_bottom_sheet_new_sentence">새 문장 추가</string>
     <string name="add_quote_bottom_sheet_button_add">추가하기</string>
+    <string name="add_quote_bottom_sheet_button_adding">추가 중입니다...</string>
 
     <!-- Add Node - Bottom Sheet -->
     <string name="add_node_bottom_sheet_title">노드 추가</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="common_cancel">취소</string>
     <string name="common_save">저장</string>
     <string name="common_error_text">에러가 발생했어요.</string>
+    <string name="common_touch_item_place">아이템을 추가할 위치를 터치하세요!</string>
 
     <!--  component  -->
     <string name="search_text_field_hint">검색어를 입력하세요.</string>


### PR DESCRIPTION
## #️⃣연관된 이슈
- #106 

## 📝작업 내용

### ✅DONE

- [x] 구절 버튼 클릭 시 인상깊은 구절 데이터가 포함된 바텀시트 출력
- [x] 새 문장 추가 버튼 클릭 시 구절 추가 다이얼로그 출력
- [x] 메모 관계도 화면의 바텀바 버튼 클릭 시 리플 효과가 아이콘 버튼에만 적용되도록 수정
- [x] 메모 관계도 화면에서 이벤트 수집 시 라이프사이클에 따라 Flow를 수집하는 확장 함수 적용
- [x] `EditableTextField` 색상 필드를 알맞는 필드에 매핑하여 수정
- [x] `QuoteCard`의 패딩을 `start`에서 `horizontal`로 수정, 좌우에 패딩 적용

### 🟩TODO

- [ ] 바텀시트에서 구절을 검색하는 기능
- [ ] 다이얼로그의 페이지를 입력하는 텍스트필드에 숫자만 입력하게 하는 필터링 기능
- [ ] `AlertMessageCard` 표시 및 `QuoteItem` 추가 동작 구현
- [ ] 새로운 구절 데이터 추가 직후 `QuoteItem` 추가 동작 구현

## 📢특이사항

- 기능 구현하면서 등장인물 추가 시에도 활용할 수 있는 함수나 uiState의 상태를 함께 만들어두었습니다.
- 만약 기능 구현 시 필요하지 않다면 삭제하셔도 무방합니다.

## 🤔시행착오

### 바텀시트의 스크롤 동작이 자연스럽지 않은 현상

- 초기에 구현한 바텀시트는 상단 시스템 UI 바 영역까지 표시되었습니다.
- 바텀시트를 아래로 드래그할 경우, 하단의 "새 문장 추가" `TextButton`과 "추가하기" `And03Button`이 먼저 드래그되고, 이후에 나머지 아이템들이 따라서 드래그되는 현상이 있었습니다.
- 드래그 시 이격이 있어 부자연스럽다고 느꼈습니다.

https://github.com/user-attachments/assets/f1098539-045b-4f05-aa65-cc90b244aa8f

- `CanvasMemoScreen`에서 `ModalBottomSheet`를 선언 시 `Modifier.windowInsetsPadding()`을 적용하여 바텀시트가 상단 시스템 UI 바에 그려지지 못하도록 설정했습니다.
- 이후 드래그 시 이격이 없어져 이전보다 부드러운 드래그 조작이 가능합니다.

## 🖼️스크린샷

- `EditableTextField` 색상을 재설정 이후의 모습입니다. 이제 텍스트필드 선택 시 테두리가 Primary 컬러로 표시됩니다.

<img width="456" height="592" alt="image" src="https://github.com/user-attachments/assets/53f6a65c-f616-4af3-a337-1583c60f36ae" />

- `QuoteCard`의 좌우에 패딩이 적용된 Preview 사진입니다.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/8d796647-b0aa-4b22-8143-fb3ef8f14a27" />

- 바텀바 버튼의 리플 효과 범위 수정 여부를 테스트하는 영상입니다.

https://github.com/user-attachments/assets/292a566e-cbdc-49da-b878-14174bd72dce

- 바텀시트 표시 및 아이템 스크롤 및 선택 동작, 다이얼로그 표시 및 취소 동작 테스트 영상입니다.

https://github.com/user-attachments/assets/1b3f89ec-6d60-4979-a209-93a71ea5913a