### PR TITLE
화면 이탈 시 다이얼로그 표시 및 데이터 로딩 시 UI 대응

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/data/datasource/remote/canvasmemo/CanvasMemoDataSourceImpl.kt
+++ b/app/src/main/java/com/boostcamp/and03/data/datasource/remote/canvasmemo/CanvasMemoDataSourceImpl.kt
@@ -31,7 +31,7 @@ class CanvasMemoDataSourceImpl @Inject constructor(
             val canvasMemoSnapshot = memoRef.get().await()
 
             if (!canvasMemoSnapshot.exists()) {
-                throw Exception("Canvas memo not found: $memoId")
+                throw NoSuchElementException("Canvas memo not found: $memoId")
             }
 
             val data = canvasMemoSnapshot.data

--- a/app/src/main/java/com/boostcamp/and03/ui/component/And03Dialog.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/And03Dialog.kt
@@ -72,7 +72,7 @@ fun And03Dialog(
                     And03Button(
                         text = dismissText,
                         onClick = onDismiss,
-                        variant = ButtonVariant.Secondary,
+                        variant = ButtonVariant.SurfaceVariant,
                         modifier = Modifier.weight(1f)
                     )
 

--- a/app/src/main/java/com/boostcamp/and03/ui/component/And03Dialog.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/component/And03Dialog.kt
@@ -15,10 +15,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
+
+enum class DialogDismissAction {
+    Dismiss,
+    Confirm
+}
 
 @Composable
 fun And03Dialog(
@@ -31,9 +37,17 @@ fun And03Dialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
     modifier: Modifier = Modifier,
-    description: String = ""
+    description: String = "",
+    dismissAction: DialogDismissAction = DialogDismissAction.Dismiss,
 ) {
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = {
+            when (dismissAction) {
+                DialogDismissAction.Dismiss -> onDismiss()
+                DialogDismissAction.Confirm -> onConfirm()
+            }
+        },
+    ) {
         Surface(
             shape = And03Theme.shapes.dialogCorner,
             color = And03Theme.colors.surface

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/BooklistScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/booklist/BooklistScreen.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.and03.ui.screen.booklist
 
-import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -47,6 +46,10 @@ fun BooklistRoute(
     onAddBookClick: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadBooks()
+    }
 
     BooklistScreen(
         uiState = uiState,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.and03.ui.screen.canvasmemo
 
-import android.graphics.Canvas
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
 import com.boostcamp.and03.ui.screen.bookdetail.model.QuoteUiModel
@@ -18,6 +17,8 @@ sealed interface CanvasMemoAction {
     data object CloseBottomSheet : CanvasMemoAction
 
     data object CloseQuoteDialog : CanvasMemoAction
+
+    data object CloseExitConfirmationDialog : CanvasMemoAction
 
     data class PrepareQuotePlacement(val quote: QuoteUiModel) : CanvasMemoAction
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
@@ -20,6 +20,8 @@ sealed interface CanvasMemoAction {
 
     data object CloseExitConfirmationDialog : CanvasMemoAction
 
+    data object CloseScreen : CanvasMemoAction
+
     data class PrepareQuotePlacement(val quote: QuoteUiModel) : CanvasMemoAction
 
     data object SaveQuote : CanvasMemoAction

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -63,6 +63,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03AppBar
+import com.boostcamp.and03.ui.component.And03Dialog
+import com.boostcamp.and03.ui.component.DialogDismissAction
 import com.boostcamp.and03.ui.screen.canvasmemo.component.AddNodeBottomSheet
 import com.boostcamp.and03.ui.screen.canvasmemo.component.AddQuoteBottomSheet
 import com.boostcamp.and03.ui.screen.canvasmemo.component.AddQuoteDialog
@@ -121,7 +123,13 @@ private fun CanvasMemoScreen(
         skipPartiallyExpanded = true
     )
 
-    BackHandler(onBack = { onAction(CanvasMemoAction.ClickBack) })
+    BackHandler {
+        if (uiState.isExitConfirmationDialogVisible) {
+            onAction(CanvasMemoAction.CloseExitConfirmationDialog)
+        } else {
+            onAction(CanvasMemoAction.ClickBack)
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -479,6 +487,21 @@ private fun CanvasMemoScreen(
                         enabled = uiState.isQuoteSaveable && !uiState.isSaving,
                         isSaving = uiState.isSaving,
                         totalPage = uiState.totalPage
+                    )
+                }
+
+                if (uiState.isExitConfirmationDialogVisible && uiState.hasUnsavedChanges) {
+                    And03Dialog(
+                        iconResId = R.drawable.ic_warning_filled,
+                        iconColor = And03Theme.colors.error,
+                        iconContentDescription = stringResource(id = R.string.content_description_caution),
+                        title = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_title),
+                        dismissText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_dismiss_text),
+                        confirmText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_confirm_text),
+                        onDismiss = { onAction(CanvasMemoAction.CloseScreen) },
+                        onConfirm = { onAction(CanvasMemoAction.CloseExitConfirmationDialog) },
+                        description = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_description),
+                        dismissAction = DialogDismissAction.Confirm
                     )
                 }
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -1,5 +1,7 @@
 package com.boostcamp.and03.ui.screen.canvasmemo
 
+import android.R.attr.onClick
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -119,6 +121,8 @@ private fun CanvasMemoScreen(
         skipPartiallyExpanded = true
     )
 
+    BackHandler(onBack = { onAction(CanvasMemoAction.ClickBack) })
+
     Scaffold(
         topBar = {
             And03AppBar(
@@ -126,6 +130,7 @@ private fun CanvasMemoScreen(
                 onBackClick = { onAction(CanvasMemoAction.ClickBack) }
             ) {
                 IconButton(
+                    enabled = uiState.hasUnsavedChanges,
                     onClick = { onAction(CanvasMemoAction.OnClickSave) }) {
                     Icon(
                         painter = painterResource(R.drawable.ic_save_filled),

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
@@ -34,6 +34,7 @@ data class CanvasMemoUiState(
     val isAddCharacterDialogVisible: Boolean = false,
     val isRelationDialogVisible: Boolean = false,
     val isQuoteDialogVisible: Boolean = false,
+    val isExitConfirmationDialogVisible: Boolean = false,
 
     val characterNameState: TextFieldState = TextFieldState(),
     val characterDescState: TextFieldState = TextFieldState(),
@@ -51,7 +52,9 @@ data class CanvasMemoUiState(
 
     val isSaving: Boolean = false,
     val quoteToPlace: QuoteUiModel? = null,
-    val quoteItemSizePx: IntSize? = null
+    val quoteItemSizePx: IntSize? = null,
+
+    val hasUnsavedChanges: Boolean = false
 ) {
     val relationDialogUiState: RelationDialogUiState
         get() = toRelationDialogState()

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
@@ -171,6 +171,8 @@ class CanvasMemoViewModel @Inject constructor(
 
             CanvasMemoAction.CloseExitConfirmationDialog -> handleCloseExitConfirmationDialog()
 
+            CanvasMemoAction.CloseScreen -> handleCloseScreen()
+
             is CanvasMemoAction.PrepareQuotePlacement -> handlePrepareQuotePlacement(action.quote)
 
             is CanvasMemoAction.SearchQuote -> handleSearchQuote(action)
@@ -304,7 +306,17 @@ class CanvasMemoViewModel @Inject constructor(
         }
     }
 
+    /**
+     * 나가기 확인 다이얼로그를 닫고, 캔버스 메모 화면에 잔류합니다.
+     */
     private fun handleCloseExitConfirmationDialog() {
+        _uiState.update { it.copy(isExitConfirmationDialogVisible = false) }
+    }
+
+    /**
+     * 나가기 확인 다이얼로그를 닫고, 이전 화면으로 이동합니다.
+     */
+    private fun handleCloseScreen() {
         _uiState.update {
             it.copy(
                 isExitConfirmationDialogVisible = false,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormAction.kt
@@ -11,4 +11,8 @@ sealed interface CanvasMemoFormAction {
     data class OnStartPageChange(val startPage: String) : CanvasMemoFormAction
 
     data class OnEndPageChange(val endPage: String) : CanvasMemoFormAction
+
+    data object CloseExitConfirmationDialog : CanvasMemoFormAction
+
+    data object CloseScreen : CanvasMemoFormAction
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormScreen.kt
@@ -2,6 +2,7 @@ package com.boostcamp.and03.ui.screen.canvasmemoform
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -14,9 +15,11 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -103,26 +106,34 @@ private fun CanvasMemoFormScreen(
             )
         }
     ) { innerPadding ->
-        Column(
-            modifier = modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(And03Padding.PADDING_L)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_L)
-        ) {
-            TitleInputSection(
-                title = uiState.title,
-                onTitleChange = { onAction(CanvasMemoFormAction.OnTitleChange(title = it)) }
-            )
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(alignment = Alignment.Center)
+                )
+            }
+        } else {
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(And03Padding.PADDING_L)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_L)
+            ) {
+                TitleInputSection(
+                    title = uiState.title,
+                    onTitleChange = { onAction(CanvasMemoFormAction.OnTitleChange(title = it)) }
+                )
 
-            PageInputSection(
-                startPage = uiState.startPage,
-                endPage = uiState.endPage,
-                onStartPageChange = { onAction(CanvasMemoFormAction.OnStartPageChange(startPage = it)) },
-                onEndPageChange = { onAction(CanvasMemoFormAction.OnEndPageChange(endPage = it)) },
-                totalPage = uiState.totalPage
-            )
+                PageInputSection(
+                    startPage = uiState.startPage,
+                    endPage = uiState.endPage,
+                    onStartPageChange = { onAction(CanvasMemoFormAction.OnStartPageChange(startPage = it)) },
+                    onEndPageChange = { onAction(CanvasMemoFormAction.OnEndPageChange(endPage = it)) },
+                    totalPage = uiState.totalPage
+                )
+            }
         }
 
         if (uiState.isEdited && uiState.isExitConfirmationDialogVisible) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormScreen.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.and03.ui.screen.canvasmemoform
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -24,9 +25,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03AppBar
 import com.boostcamp.and03.ui.component.And03Button
+import com.boostcamp.and03.ui.component.And03Dialog
 import com.boostcamp.and03.ui.component.ButtonVariant
+import com.boostcamp.and03.ui.component.DialogDismissAction
 import com.boostcamp.and03.ui.component.PageInputSection
 import com.boostcamp.and03.ui.component.TitleInputSection
+import com.boostcamp.and03.ui.screen.textmemoform.TextMemoFormAction
 import com.boostcamp.and03.ui.theme.And03ComponentSize
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
@@ -60,6 +64,16 @@ private fun CanvasMemoFormScreen(
     onAction: (CanvasMemoFormAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    BackHandler {
+        if (uiState.isExitConfirmationDialogVisible) {
+            onAction(CanvasMemoFormAction.CloseExitConfirmationDialog)
+        } else if (uiState.isEdited) {
+            onAction(CanvasMemoFormAction.OnBackClick)
+        } else {
+            onAction(CanvasMemoFormAction.CloseScreen)
+        }
+    }
+
     Scaffold(
         topBar = {
             And03AppBar(
@@ -108,6 +122,21 @@ private fun CanvasMemoFormScreen(
                 onStartPageChange = { onAction(CanvasMemoFormAction.OnStartPageChange(startPage = it)) },
                 onEndPageChange = { onAction(CanvasMemoFormAction.OnEndPageChange(endPage = it)) },
                 totalPage = uiState.totalPage
+            )
+        }
+
+        if (uiState.isEdited && uiState.isExitConfirmationDialogVisible) {
+            And03Dialog(
+                iconResId = R.drawable.ic_warning_filled,
+                iconColor = And03Theme.colors.error,
+                iconContentDescription = stringResource(id = R.string.content_description_caution),
+                title = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_title),
+                dismissText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_dismiss_text),
+                confirmText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_confirm_text),
+                onDismiss = { onAction(CanvasMemoFormAction.CloseScreen) },
+                onConfirm = { onAction(CanvasMemoFormAction.CloseExitConfirmationDialog) },
+                description = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_description),
+                dismissAction = DialogDismissAction.Confirm
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormUiState.kt
@@ -4,6 +4,11 @@ data class CanvasMemoFormUiState(
     val title: String = "",
     val startPage: String = "",
     val endPage: String = "",
+
+    val originalTitle: String = "",
+    val originalStartPage: String = "",
+    val originalEndPage: String = "",
+
     val totalPage: Int = 0,
     val isSaving: Boolean = false,
     val isExitConfirmationDialogVisible: Boolean = false
@@ -27,5 +32,7 @@ data class CanvasMemoFormUiState(
         }
 
     val isEdited: Boolean
-        get() = title.isNotBlank() || startPage.isNotBlank() || endPage.isNotBlank()
+        get() = title != originalTitle ||
+                startPage != originalStartPage ||
+                endPage != originalEndPage
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormUiState.kt
@@ -9,6 +9,7 @@ data class CanvasMemoFormUiState(
     val originalStartPage: String = "",
     val originalEndPage: String = "",
 
+    val isLoading: Boolean = false,
     val totalPage: Int = 0,
     val isSaving: Boolean = false,
     val isExitConfirmationDialogVisible: Boolean = false

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormUiState.kt
@@ -5,7 +5,8 @@ data class CanvasMemoFormUiState(
     val startPage: String = "",
     val endPage: String = "",
     val totalPage: Int = 0,
-    val isSaving: Boolean = false
+    val isSaving: Boolean = false,
+    val isExitConfirmationDialogVisible: Boolean = false
 ) {
     val isValidPageRange: Boolean
         get() {
@@ -24,4 +25,7 @@ data class CanvasMemoFormUiState(
         get() {
             return title.isNotBlank() && isValidPageRange
         }
+
+    val isEdited: Boolean
+        get() = title.isNotBlank() || startPage.isNotBlank() || endPage.isNotBlank()
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormViewModel.kt
@@ -91,7 +91,10 @@ class CanvasMemoFormViewModel @Inject constructor(
             it.copy(
                 title = result.title,
                 startPage = result.startPage.toString(),
-                endPage = if (isSamePage) "" else result.endPage.toString()
+                endPage = if (isSamePage) "" else result.endPage.toString(),
+                originalTitle = result.title,
+                originalStartPage = result.startPage.toString(),
+                originalEndPage = if (isSamePage) "" else result.endPage.toString()
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormViewModel.kt
@@ -42,7 +42,7 @@ class CanvasMemoFormViewModel @Inject constructor(
 
     fun onAction(action: CanvasMemoFormAction) {
         when (action) {
-            CanvasMemoFormAction.OnBackClick -> _event.trySend(CanvasMemoFormEvent.NavigateBack)
+            CanvasMemoFormAction.OnBackClick -> _uiState.update { it.copy(isExitConfirmationDialogVisible = true) }
 
             CanvasMemoFormAction.OnSaveClick -> {
                 viewModelScope.launch {
@@ -66,6 +66,13 @@ class CanvasMemoFormViewModel @Inject constructor(
             is CanvasMemoFormAction.OnStartPageChange -> _uiState.update { it.copy(startPage = action.startPage) }
 
             is CanvasMemoFormAction.OnEndPageChange -> _uiState.update { it.copy(endPage = action.endPage) }
+
+            CanvasMemoFormAction.CloseExitConfirmationDialog -> _uiState.update { it.copy(isExitConfirmationDialogVisible = false) }
+
+            CanvasMemoFormAction.CloseScreen -> {
+                _uiState.update { it.copy(isExitConfirmationDialogVisible = false) }
+                _event.trySend(CanvasMemoFormEvent.NavigateBack)
+            }
         }
     }
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormViewModel.kt
@@ -36,8 +36,18 @@ class CanvasMemoFormViewModel @Inject constructor(
     private val userId: String = "O12OmGoVY8FPYFElNjKN"
 
     init {
-        _uiState.update { it.copy(totalPage = totalPage) }
-        viewModelScope.launch { loadTextMemo() }
+        _uiState.update {
+            it.copy(
+                isLoading = memoId.isNotBlank(),
+                totalPage = totalPage
+            )
+        }
+
+        if (memoId.isNotBlank()) {
+            viewModelScope.launch {
+                loadCanvasMemo()
+            }
+        }
     }
 
     fun onAction(action: CanvasMemoFormAction) {
@@ -76,9 +86,7 @@ class CanvasMemoFormViewModel @Inject constructor(
         }
     }
 
-    private suspend fun loadTextMemo() {
-        if (memoId.isBlank()) return
-
+    private suspend fun loadCanvasMemo() {
         val result = bookStorageRepository.getCanvasMemo(
             userId = userId,
             bookId = bookId,
@@ -94,7 +102,8 @@ class CanvasMemoFormViewModel @Inject constructor(
                 endPage = if (isSamePage) "" else result.endPage.toString(),
                 originalTitle = result.title,
                 originalStartPage = result.startPage.toString(),
-                originalEndPage = if (isSamePage) "" else result.endPage.toString()
+                originalEndPage = if (isSamePage) "" else result.endPage.toString(),
+                totalPage = totalPage
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemoform/CanvasMemoFormViewModel.kt
@@ -103,7 +103,8 @@ class CanvasMemoFormViewModel @Inject constructor(
                 originalTitle = result.title,
                 originalStartPage = result.startPage.toString(),
                 originalEndPage = if (isSamePage) "" else result.endPage.toString(),
-                totalPage = totalPage
+                totalPage = totalPage,
+                isLoading = false
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormAction.kt
@@ -13,4 +13,8 @@ sealed interface CharacterFormAction {
     data class OnRoleChange(val role: String): CharacterFormAction
 
     data class OnDescriptionChange(val description: String): CharacterFormAction
+
+    data object CloseExitConfirmationDialog : CharacterFormAction
+
+    data object CloseScreen : CharacterFormAction
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormScreen.kt
@@ -3,6 +3,7 @@ package com.boostcamp.and03.ui.screen.characterform
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -111,43 +113,51 @@ private fun CharacterFormScreen(
             )
         }
     ) { innerPadding ->
-        Column(
-            modifier = modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(And03Padding.PADDING_L)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_L),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            And03InfoSection(
-                title = stringResource(R.string.info_section_character_title),
-                description = stringResource(R.string.info_section_character_description)
-            )
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(alignment = Alignment.Center)
+                )
+            }
+        } else {
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(And03Padding.PADDING_L)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_L),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                And03InfoSection(
+                    title = stringResource(R.string.info_section_character_title),
+                    description = stringResource(R.string.info_section_character_description)
+                )
 
-            PersonImagePlaceholder(
-                imageUrl = null,
-                onClick = { onAction(CharacterFormAction.OnAddImageClick) }
-            )
+                PersonImagePlaceholder(
+                    imageUrl = null,
+                    onClick = { onAction(CharacterFormAction.OnAddImageClick) }
+                )
 
-            SingleLineInputSection(
-                value = uiState.name,
-                onValueChange = { onAction(CharacterFormAction.OnNameChange(name = it)) },
-                labelStringRes = R.string.character_form_name,
-                placeholderStringRes = R.string.character_form_enter_name_placeholder
-            )
+                SingleLineInputSection(
+                    value = uiState.name,
+                    onValueChange = { onAction(CharacterFormAction.OnNameChange(name = it)) },
+                    labelStringRes = R.string.character_form_name,
+                    placeholderStringRes = R.string.character_form_enter_name_placeholder
+                )
 
-            SingleLineInputSection(
-                value = uiState.role,
-                onValueChange = { onAction(CharacterFormAction.OnRoleChange(role = it)) },
-                labelStringRes = R.string.character_form_role,
-                placeholderStringRes = R.string.character_form_enter_role_placeholder
-            )
+                SingleLineInputSection(
+                    value = uiState.role,
+                    onValueChange = { onAction(CharacterFormAction.OnRoleChange(role = it)) },
+                    labelStringRes = R.string.character_form_role,
+                    placeholderStringRes = R.string.character_form_enter_role_placeholder
+                )
 
-            DescriptionInputSection(
-                description = uiState.description,
-                onDescriptionChange = { onAction(CharacterFormAction.OnDescriptionChange(description = it)) }
-            )
+                DescriptionInputSection(
+                    description = uiState.description,
+                    onDescriptionChange = { onAction(CharacterFormAction.OnDescriptionChange(description = it)) }
+                )
+            }
         }
 
         if (uiState.isEdited && uiState.isExitConfirmationDialogVisible) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormScreen.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.and03.ui.screen.characterform
 
+import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -8,8 +9,6 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -33,8 +32,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03AppBar
 import com.boostcamp.and03.ui.component.And03Button
+import com.boostcamp.and03.ui.component.And03Dialog
 import com.boostcamp.and03.ui.component.And03InfoSection
 import com.boostcamp.and03.ui.component.ButtonVariant
+import com.boostcamp.and03.ui.component.DialogDismissAction
 import com.boostcamp.and03.ui.screen.canvasmemo.component.PersonImagePlaceholder
 import com.boostcamp.and03.ui.theme.And03ComponentSize
 import com.boostcamp.and03.ui.theme.And03Padding
@@ -71,6 +72,16 @@ private fun CharacterFormScreen(
     onAction: (CharacterFormAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    BackHandler {
+        if (uiState.isExitConfirmationDialogVisible) {
+            onAction(CharacterFormAction.CloseExitConfirmationDialog)
+        } else if (uiState.isEdited) {
+            onAction(CharacterFormAction.OnBackClick)
+        } else {
+            onAction(CharacterFormAction.CloseScreen)
+        }
+    }
+
     Scaffold(
         topBar = {
             And03AppBar(
@@ -136,6 +147,21 @@ private fun CharacterFormScreen(
             DescriptionInputSection(
                 description = uiState.description,
                 onDescriptionChange = { onAction(CharacterFormAction.OnDescriptionChange(description = it)) }
+            )
+        }
+
+        if (uiState.isEdited && uiState.isExitConfirmationDialogVisible) {
+            And03Dialog(
+                iconResId = R.drawable.ic_warning_filled,
+                iconColor = And03Theme.colors.error,
+                iconContentDescription = stringResource(id = R.string.content_description_caution),
+                title = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_title),
+                dismissText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_dismiss_text),
+                confirmText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_confirm_text),
+                onDismiss = { onAction(CharacterFormAction.CloseScreen) },
+                onConfirm = { onAction(CharacterFormAction.CloseExitConfirmationDialog) },
+                description = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_description),
+                dismissAction = DialogDismissAction.Confirm
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormUiState.kt
@@ -13,6 +13,7 @@ data class CharacterFormUiState(
     val originalDescription: String = "",
     val originalImageUrl: String = "",
 
+    val isLoading: Boolean = false,
     val iconColor: Color = Color(0xFF1E88E5),
     val isSaving: Boolean = false,
     val isExitConfirmationDialogVisible: Boolean = false

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormUiState.kt
@@ -7,6 +7,12 @@ data class CharacterFormUiState(
     val role: String = "",
     val description: String = "",
     val imageUrl: String = "",
+
+    val originalName: String = "",
+    val originalRole: String = "",
+    val originalDescription: String = "",
+    val originalImageUrl: String = "",
+
     val iconColor: Color = Color(0xFF1E88E5),
     val isSaving: Boolean = false,
     val isExitConfirmationDialogVisible: Boolean = false
@@ -15,8 +21,8 @@ data class CharacterFormUiState(
         get() = name.isNotBlank()
 
     val isEdited: Boolean
-        get() = name.isNotBlank() ||
-                role.isNotBlank() ||
-                description.isNotBlank() ||
-                imageUrl.isNotBlank()
+        get() = name != originalName ||
+                role != originalRole ||
+                description != originalDescription ||
+                imageUrl != originalImageUrl
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormUiState.kt
@@ -8,8 +8,15 @@ data class CharacterFormUiState(
     val description: String = "",
     val imageUrl: String = "",
     val iconColor: Color = Color(0xFF1E88E5),
-    val isSaving: Boolean = false
+    val isSaving: Boolean = false,
+    val isExitConfirmationDialogVisible: Boolean = false
 ) {
     val isSaveable: Boolean
         get() = name.isNotBlank()
+
+    val isEdited: Boolean
+        get() = name.isNotBlank() ||
+                role.isNotBlank() ||
+                description.isNotBlank() ||
+                imageUrl.isNotBlank()
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormViewModel.kt
@@ -36,7 +36,7 @@ class CharacterFormViewModel @Inject constructor (
 
     fun onAction(action: CharacterFormAction) {
         when (action) {
-            CharacterFormAction.OnBackClick -> _event.trySend(CharacterFormEvent.NavigateBack)
+            CharacterFormAction.OnBackClick -> _uiState.update { it.copy(isExitConfirmationDialogVisible = true) }
 
             CharacterFormAction.OnSaveClick -> {
                 viewModelScope.launch {
@@ -62,6 +62,13 @@ class CharacterFormViewModel @Inject constructor (
             is CharacterFormAction.OnRoleChange -> _uiState.update { it.copy(role = action.role) }
 
             is CharacterFormAction.OnDescriptionChange -> _uiState.update { it.copy(description = action.description) }
+
+            CharacterFormAction.CloseExitConfirmationDialog -> _uiState.update { it.copy(isExitConfirmationDialogVisible = false) }
+
+            CharacterFormAction.CloseScreen -> {
+                _uiState.update { it.copy(isExitConfirmationDialogVisible = false) }
+                _event.trySend(CharacterFormEvent.NavigateBack)
+            }
         }
     }
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormViewModel.kt
@@ -73,8 +73,10 @@ class CharacterFormViewModel @Inject constructor (
     }
 
     init {
-        viewModelScope.launch {
-            loadCharacter()
+        _uiState.update { it.copy(isLoading = characterId.isNotBlank()) }
+
+        if (characterId.isNotBlank()) {
+            viewModelScope.launch { loadCharacter() }
         }
     }
 
@@ -94,7 +96,8 @@ class CharacterFormViewModel @Inject constructor (
                 description = result.description,
                 originalName = result.name,
                 originalRole = result.role,
-                originalDescription = result.description
+                originalDescription = result.description,
+                isLoading = false
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/characterform/CharacterFormViewModel.kt
@@ -91,7 +91,10 @@ class CharacterFormViewModel @Inject constructor (
             it.copy(
                 name = result.name,
                 role = result.role,
-                description = result.description
+                description = result.description,
+                originalName = result.name,
+                originalRole = result.role,
+                originalDescription = result.description
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormAction.kt
@@ -9,4 +9,8 @@ sealed interface QuoteFormAction {
     data class OnQuoteChange(val quote: String): QuoteFormAction
 
     data class OnPageChange(val page: String): QuoteFormAction
+
+    data object CloseScreen: QuoteFormAction
+
+    data object CloseExitConfirmationDialog: QuoteFormAction
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormScreen.kt
@@ -2,6 +2,7 @@ package com.boostcamp.and03.ui.screen.quoteform
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -117,39 +119,47 @@ private fun QuoteFormScreen(
             )
         }
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(And03Padding.PADDING_L)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_L),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            And03InfoSection(
-                title = stringResource(R.string.add_quote_info_title),
-                description = stringResource(R.string.add_quote_info_description)
-            )
-
-            QuoteInputSection(
-                quote = uiState.quote,
-                onQuoteChange = { onAction(QuoteFormAction.OnQuoteChange(quote = it)) },
-                onAddByImageClick = { isOCRBottomSheetVisible = true }
-            )
-
-            if (isOCRBottomSheetVisible) {
-                OCRBottomSheet(
-                    onDismiss = { isOCRBottomSheetVisible = false },
-                    onCameraClick = { /* TODO: 텍스트 가져오기 기능 구현 */ },
-                    onGalleryClick = { /* TODO: 사진 촬영 기능 구현 */ }
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(alignment = Alignment.Center)
                 )
             }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(And03Padding.PADDING_L)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_L),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                And03InfoSection(
+                    title = stringResource(R.string.add_quote_info_title),
+                    description = stringResource(R.string.add_quote_info_description)
+                )
 
-            PageInputSection(
-                page = uiState.page,
-                onPageChange = { onAction(QuoteFormAction.OnPageChange(page = it)) },
-                totalPage = uiState.totalPage
-            )
+                QuoteInputSection(
+                    quote = uiState.quote,
+                    onQuoteChange = { onAction(QuoteFormAction.OnQuoteChange(quote = it)) },
+                    onAddByImageClick = { isOCRBottomSheetVisible = true }
+                )
+
+                if (isOCRBottomSheetVisible) {
+                    OCRBottomSheet(
+                        onDismiss = { isOCRBottomSheetVisible = false },
+                        onCameraClick = { /* TODO: 텍스트 가져오기 기능 구현 */ },
+                        onGalleryClick = { /* TODO: 사진 촬영 기능 구현 */ }
+                    )
+                }
+
+                PageInputSection(
+                    page = uiState.page,
+                    onPageChange = { onAction(QuoteFormAction.OnPageChange(page = it)) },
+                    totalPage = uiState.totalPage
+                )
+            }
         }
 
         if (uiState.isEdited && uiState.isExitConfirmationDialogVisible) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormScreen.kt
@@ -42,8 +42,6 @@ import com.boostcamp.and03.ui.component.And03InfoSection
 import com.boostcamp.and03.ui.component.ButtonVariant
 import com.boostcamp.and03.ui.component.DialogDismissAction
 import com.boostcamp.and03.ui.component.OCRBottomSheet
-import com.boostcamp.and03.ui.component.PageInputSection
-import com.boostcamp.and03.ui.screen.textmemoform.TextMemoFormAction
 import com.boostcamp.and03.ui.theme.And03ComponentSize
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
@@ -83,7 +81,7 @@ private fun QuoteFormScreen(
     BackHandler {
         if (uiState.isExitConfirmationDialogVisible) {
             onAction(QuoteFormAction.CloseExitConfirmationDialog)
-        } else if (uiState.isTyped) {
+        } else if (uiState.isEdited) {
             onAction(QuoteFormAction.OnBackClick)
         } else {
             onAction(QuoteFormAction.CloseScreen)
@@ -154,7 +152,7 @@ private fun QuoteFormScreen(
             )
         }
 
-        if (uiState.isTyped && uiState.isExitConfirmationDialogVisible) {
+        if (uiState.isEdited && uiState.isExitConfirmationDialogVisible) {
             And03Dialog(
                 iconResId = R.drawable.ic_warning_filled,
                 iconColor = And03Theme.colors.error,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormScreen.kt
@@ -1,5 +1,6 @@
 package com.boostcamp.and03.ui.screen.quoteform
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -36,10 +37,13 @@ import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.AddTextByImageButton
 import com.boostcamp.and03.ui.component.And03AppBar
 import com.boostcamp.and03.ui.component.And03Button
+import com.boostcamp.and03.ui.component.And03Dialog
 import com.boostcamp.and03.ui.component.And03InfoSection
 import com.boostcamp.and03.ui.component.ButtonVariant
+import com.boostcamp.and03.ui.component.DialogDismissAction
 import com.boostcamp.and03.ui.component.OCRBottomSheet
 import com.boostcamp.and03.ui.component.PageInputSection
+import com.boostcamp.and03.ui.screen.textmemoform.TextMemoFormAction
 import com.boostcamp.and03.ui.theme.And03ComponentSize
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
@@ -75,6 +79,16 @@ private fun QuoteFormScreen(
     onAction: (QuoteFormAction) -> Unit,
 ) {
     var isOCRBottomSheetVisible by remember { mutableStateOf(false) }
+
+    BackHandler {
+        if (uiState.isExitConfirmationDialogVisible) {
+            onAction(QuoteFormAction.CloseExitConfirmationDialog)
+        } else if (uiState.isTyped) {
+            onAction(QuoteFormAction.OnBackClick)
+        } else {
+            onAction(QuoteFormAction.CloseScreen)
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -137,6 +151,21 @@ private fun QuoteFormScreen(
                 page = uiState.page,
                 onPageChange = { onAction(QuoteFormAction.OnPageChange(page = it)) },
                 totalPage = uiState.totalPage
+            )
+        }
+
+        if (uiState.isTyped && uiState.isExitConfirmationDialogVisible) {
+            And03Dialog(
+                iconResId = R.drawable.ic_warning_filled,
+                iconColor = And03Theme.colors.error,
+                iconContentDescription = stringResource(id = R.string.content_description_caution),
+                title = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_title),
+                dismissText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_dismiss_text),
+                confirmText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_confirm_text),
+                onDismiss = { onAction(QuoteFormAction.CloseScreen) },
+                onConfirm = { onAction(QuoteFormAction.CloseExitConfirmationDialog) },
+                description = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_description),
+                dismissAction = DialogDismissAction.Confirm
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormUiState.kt
@@ -3,6 +3,10 @@ package com.boostcamp.and03.ui.screen.quoteform
 data class QuoteFormUiState(
     val quote: String = "",
     val page: String = "",
+
+    val originalQuote: String = "",
+    val originalPage: String = "",
+
     val totalPage: Int = 0,
     val isSaving: Boolean = false,
     val isExitConfirmationDialogVisible: Boolean = false
@@ -14,5 +18,5 @@ data class QuoteFormUiState(
         get() = quote.isNotBlank() && isValidPage
 
     val isEdited: Boolean
-        get() = quote.isNotBlank() || page.isNotBlank()
+        get() = quote != originalQuote || page != originalPage
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormUiState.kt
@@ -13,6 +13,6 @@ data class QuoteFormUiState(
     val isSaveable: Boolean
         get() = quote.isNotBlank() && isValidPage
 
-    val isTyped: Boolean
+    val isEdited: Boolean
         get() = quote.isNotBlank() || page.isNotBlank()
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormUiState.kt
@@ -4,11 +4,15 @@ data class QuoteFormUiState(
     val quote: String = "",
     val page: String = "",
     val totalPage: Int = 0,
-    val isSaving: Boolean = false
+    val isSaving: Boolean = false,
+    val isExitConfirmationDialogVisible: Boolean = false
 ) {
     val isValidPage: Boolean
         get() = page.trim().toIntOrNull() in 1..totalPage
 
     val isSaveable: Boolean
         get() = quote.isNotBlank() && isValidPage
+
+    val isTyped: Boolean
+        get() = quote.isNotBlank() || page.isNotBlank()
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormUiState.kt
@@ -7,6 +7,7 @@ data class QuoteFormUiState(
     val originalQuote: String = "",
     val originalPage: String = "",
 
+    val isLoading: Boolean = false,
     val totalPage: Int = 0,
     val isSaving: Boolean = false,
     val isExitConfirmationDialogVisible: Boolean = false

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormViewModel.kt
@@ -72,8 +72,16 @@ class QuoteFormViewModel @Inject constructor(
     }
 
     init {
-        _uiState.update { it.copy(totalPage = totalPage) }
-        viewModelScope.launch { loadQuote() }
+        _uiState.update {
+            it.copy(
+                totalPage = totalPage,
+                isLoading = quoteId.isNotBlank()
+            )
+        }
+
+        if (quoteId.isNotBlank()) {
+            viewModelScope.launch { loadQuote() }
+        }
     }
 
     private suspend fun loadQuote() {
@@ -90,7 +98,8 @@ class QuoteFormViewModel @Inject constructor(
                 quote = result.content,
                 page = result.page.toString(),
                 originalQuote = result.content,
-                originalPage = result.page.toString()
+                originalPage = result.page.toString(),
+                isLoading = false
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormViewModel.kt
@@ -88,7 +88,9 @@ class QuoteFormViewModel @Inject constructor(
         _uiState.update {
             it.copy(
                 quote = result.content,
-                page = result.page.toString()
+                page = result.page.toString(),
+                originalQuote = result.content,
+                originalPage = result.page.toString()
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/quoteform/QuoteFormViewModel.kt
@@ -37,7 +37,7 @@ class QuoteFormViewModel @Inject constructor(
 
     fun onAction(action: QuoteFormAction) {
         when (action) {
-            QuoteFormAction.OnBackClick -> _event.trySend(QuoteFormEvent.NavigateBack)
+            QuoteFormAction.OnBackClick -> _uiState.update { it.copy(isExitConfirmationDialogVisible = true) }
 
             QuoteFormAction.OnSaveClick -> {
                 viewModelScope.launch {
@@ -60,6 +60,13 @@ class QuoteFormViewModel @Inject constructor(
 
             is QuoteFormAction.OnPageChange -> {
                 _uiState.update { it.copy(page = action.page.filter { char -> char.isDigit() }) }
+            }
+
+            QuoteFormAction.CloseExitConfirmationDialog -> _uiState.update { it.copy(isExitConfirmationDialogVisible = false) }
+
+            QuoteFormAction.CloseScreen -> {
+                _uiState.update { it.copy(isExitConfirmationDialogVisible = false) }
+                _event.trySend(QuoteFormEvent.NavigateBack)
             }
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormAction.kt
@@ -13,4 +13,8 @@ sealed interface TextMemoFormAction {
     data class OnStartPageChange(val startPage: String) : TextMemoFormAction
 
     data class OnEndPageChange(val endPage: String) : TextMemoFormAction
+
+    data object CloseExitConfirmationDialog : TextMemoFormAction
+
+    data object CloseScreen : TextMemoFormAction
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormScreen.kt
@@ -1,5 +1,7 @@
 package com.boostcamp.and03.ui.screen.textmemoform
 
+import android.util.Log.i
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -28,11 +30,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03AppBar
 import com.boostcamp.and03.ui.component.And03Button
+import com.boostcamp.and03.ui.component.And03Dialog
 import com.boostcamp.and03.ui.component.ButtonVariant
 import com.boostcamp.and03.ui.component.ContentInputSection
+import com.boostcamp.and03.ui.component.DialogDismissAction
 import com.boostcamp.and03.ui.component.OCRBottomSheet
 import com.boostcamp.and03.ui.component.PageInputSection
 import com.boostcamp.and03.ui.component.TitleInputSection
+import com.boostcamp.and03.ui.screen.canvasmemo.CanvasMemoAction
 import com.boostcamp.and03.ui.theme.And03ComponentSize
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
@@ -65,6 +70,16 @@ private fun TextMemoFormScreen(
     modifier: Modifier = Modifier
 ) {
     var isOCRBottomSheetVisible by remember { mutableStateOf(false) }
+
+    BackHandler {
+        if (uiState.isExitConfirmationDialogVisible) {
+            onAction(TextMemoFormAction.CloseExitConfirmationDialog)
+        } else if (uiState.isTyped) {
+            onAction(TextMemoFormAction.OnBackClick)
+        } else {
+            onAction(TextMemoFormAction.CloseScreen)
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -129,6 +144,21 @@ private fun TextMemoFormScreen(
                 onStartPageChange = { onAction(TextMemoFormAction.OnStartPageChange(startPage = it)) },
                 onEndPageChange = { onAction(TextMemoFormAction.OnEndPageChange(endPage = it)) },
                 totalPage = uiState.totalPage
+            )
+        }
+
+        if (uiState.isTyped && uiState.isExitConfirmationDialogVisible) {
+            And03Dialog(
+                iconResId = R.drawable.ic_warning_filled,
+                iconColor = And03Theme.colors.error,
+                iconContentDescription = stringResource(id = R.string.content_description_caution),
+                title = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_title),
+                dismissText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_dismiss_text),
+                confirmText = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_confirm_text),
+                onDismiss = { onAction(TextMemoFormAction.CloseScreen) },
+                onConfirm = { onAction(TextMemoFormAction.CloseExitConfirmationDialog) },
+                description = stringResource(id = R.string.canvas_memo_exit_confirmation_dialog_description),
+                dismissAction = DialogDismissAction.Confirm
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormScreen.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.and03.ui.screen.textmemoform
 
-import android.util.Log.i
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -9,7 +8,6 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -37,7 +35,6 @@ import com.boostcamp.and03.ui.component.DialogDismissAction
 import com.boostcamp.and03.ui.component.OCRBottomSheet
 import com.boostcamp.and03.ui.component.PageInputSection
 import com.boostcamp.and03.ui.component.TitleInputSection
-import com.boostcamp.and03.ui.screen.canvasmemo.CanvasMemoAction
 import com.boostcamp.and03.ui.theme.And03ComponentSize
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Spacing
@@ -74,7 +71,7 @@ private fun TextMemoFormScreen(
     BackHandler {
         if (uiState.isExitConfirmationDialogVisible) {
             onAction(TextMemoFormAction.CloseExitConfirmationDialog)
-        } else if (uiState.isTyped) {
+        } else if (uiState.isEdited) {
             onAction(TextMemoFormAction.OnBackClick)
         } else {
             onAction(TextMemoFormAction.CloseScreen)
@@ -147,7 +144,7 @@ private fun TextMemoFormScreen(
             )
         }
 
-        if (uiState.isTyped && uiState.isExitConfirmationDialogVisible) {
+        if (uiState.isEdited && uiState.isExitConfirmationDialogVisible) {
             And03Dialog(
                 iconResId = R.drawable.ic_warning_filled,
                 iconColor = And03Theme.colors.error,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormScreen.kt
@@ -2,6 +2,7 @@ package com.boostcamp.and03.ui.screen.textmemoform
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -14,12 +15,14 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -107,41 +110,49 @@ private fun TextMemoFormScreen(
             )
         }
     ) { innerPadding ->
-        Column(
-            modifier = modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(And03Padding.PADDING_L)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_L)
-        ) {
-            TitleInputSection(
-                title = uiState.title,
-                onTitleChange = { onAction(TextMemoFormAction.OnTitleChange(title = it)) }
-            )
-
-            ContentInputSection(
-                label = stringResource(R.string.add_memo_content),
-                content = uiState.content,
-                onContentChange = { onAction(TextMemoFormAction.OnContentChange(content = it)) },
-                onAddByImageClick = { isOCRBottomSheetVisible = true },
-            )
-
-            if (isOCRBottomSheetVisible) {
-                OCRBottomSheet(
-                    onDismiss = { isOCRBottomSheetVisible = false },
-                    onCameraClick = { /* TODO: 텍스트 가져오기 기능 구현 */ },
-                    onGalleryClick = { /* TODO: 사진 촬영 기능 구현 */ }
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(alignment = Alignment.Center)
                 )
             }
+        } else {
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(And03Padding.PADDING_L)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_L)
+            ) {
+                TitleInputSection(
+                    title = uiState.title,
+                    onTitleChange = { onAction(TextMemoFormAction.OnTitleChange(title = it)) }
+                )
 
-            PageInputSection(
-                startPage = uiState.startPage,
-                endPage = uiState.endPage,
-                onStartPageChange = { onAction(TextMemoFormAction.OnStartPageChange(startPage = it)) },
-                onEndPageChange = { onAction(TextMemoFormAction.OnEndPageChange(endPage = it)) },
-                totalPage = uiState.totalPage
-            )
+                ContentInputSection(
+                    label = stringResource(R.string.add_memo_content),
+                    content = uiState.content,
+                    onContentChange = { onAction(TextMemoFormAction.OnContentChange(content = it)) },
+                    onAddByImageClick = { isOCRBottomSheetVisible = true },
+                )
+
+                if (isOCRBottomSheetVisible) {
+                    OCRBottomSheet(
+                        onDismiss = { isOCRBottomSheetVisible = false },
+                        onCameraClick = { /* TODO: 텍스트 가져오기 기능 구현 */ },
+                        onGalleryClick = { /* TODO: 사진 촬영 기능 구현 */ }
+                    )
+                }
+
+                PageInputSection(
+                    startPage = uiState.startPage,
+                    endPage = uiState.endPage,
+                    onStartPageChange = { onAction(TextMemoFormAction.OnStartPageChange(startPage = it)) },
+                    onEndPageChange = { onAction(TextMemoFormAction.OnEndPageChange(endPage = it)) },
+                    totalPage = uiState.totalPage
+                )
+            }
         }
 
         if (uiState.isEdited && uiState.isExitConfirmationDialogVisible) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormUiState.kt
@@ -6,7 +6,8 @@ data class TextMemoFormUiState(
     val startPage: String = "",
     val endPage: String = "",
     val totalPage: Int = 0,
-    val isSaving: Boolean = false
+    val isSaving: Boolean = false,
+    val isExitConfirmationDialogVisible: Boolean = false
 ) {
     val isValidPageRange: Boolean
         get() {
@@ -26,5 +27,13 @@ data class TextMemoFormUiState(
             return title.isNotBlank() &&
                     content.isNotBlank() &&
                     isValidPageRange
+        }
+
+    val isTyped: Boolean
+        get() {
+            return title.isNotBlank() ||
+                    content.isNotBlank() ||
+                    startPage.isNotBlank() ||
+                    endPage.isNotBlank()
         }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormUiState.kt
@@ -29,7 +29,7 @@ data class TextMemoFormUiState(
                     isValidPageRange
         }
 
-    val isTyped: Boolean
+    val isEdited: Boolean
         get() {
             return title.isNotBlank() ||
                     content.isNotBlank() ||

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormUiState.kt
@@ -5,6 +5,12 @@ data class TextMemoFormUiState(
     val content: String = "",
     val startPage: String = "",
     val endPage: String = "",
+
+    val originalTitle: String = "",
+    val originalContent: String = "",
+    val originalStartPage: String = "",
+    val originalEndPage: String = "",
+
     val totalPage: Int = 0,
     val isSaving: Boolean = false,
     val isExitConfirmationDialogVisible: Boolean = false
@@ -31,9 +37,9 @@ data class TextMemoFormUiState(
 
     val isEdited: Boolean
         get() {
-            return title.isNotBlank() ||
-                    content.isNotBlank() ||
-                    startPage.isNotBlank() ||
-                    endPage.isNotBlank()
+            return title != originalTitle ||
+                    content != originalContent ||
+                    startPage != originalStartPage ||
+                    endPage != originalEndPage
         }
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormUiState.kt
@@ -11,6 +11,7 @@ data class TextMemoFormUiState(
     val originalStartPage: String = "",
     val originalEndPage: String = "",
 
+    val isLoading: Boolean = false,
     val totalPage: Int = 0,
     val isSaving: Boolean = false,
     val isExitConfirmationDialogVisible: Boolean = false

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormViewModel.kt
@@ -42,7 +42,7 @@ class TextMemoFormViewModel @Inject constructor(
 
     fun onAction(action: TextMemoFormAction) {
         when (action) {
-            TextMemoFormAction.OnBackClick -> _event.trySend(TextMemoFormEvent.NavigateBack)
+            TextMemoFormAction.OnBackClick -> _uiState.update { it.copy(isExitConfirmationDialogVisible = true) }
 
             TextMemoFormAction.OnSaveClick -> {
                 viewModelScope.launch {
@@ -68,6 +68,13 @@ class TextMemoFormViewModel @Inject constructor(
             is TextMemoFormAction.OnStartPageChange -> _uiState.update { it.copy(startPage = action.startPage) }
 
             is TextMemoFormAction.OnEndPageChange -> _uiState.update { it.copy(endPage = action.endPage) }
+
+            TextMemoFormAction.CloseExitConfirmationDialog -> _uiState.update { it.copy(isExitConfirmationDialogVisible = false) }
+
+            TextMemoFormAction.CloseScreen -> {
+                _uiState.update { it.copy(isExitConfirmationDialogVisible = false) }
+                _event.trySend(TextMemoFormEvent.NavigateBack)
+            }
         }
     }
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormViewModel.kt
@@ -94,7 +94,11 @@ class TextMemoFormViewModel @Inject constructor(
                 title = result.title,
                 content = result.content,
                 startPage = result.startPage.toString(),
-                endPage = if (isSamePage) "" else result.endPage.toString()
+                endPage = if (isSamePage) "" else result.endPage.toString(),
+                originalTitle = result.title,
+                originalContent = result.content,
+                originalStartPage = result.startPage.toString(),
+                originalEndPage = if (isSamePage) "" else result.endPage.toString()
             )
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/textmemoform/TextMemoFormViewModel.kt
@@ -36,8 +36,16 @@ class TextMemoFormViewModel @Inject constructor(
     private val userId: String = "O12OmGoVY8FPYFElNjKN"
 
     init {
-        _uiState.update { it.copy(totalPage = totalPage) }
-        viewModelScope.launch { loadTextMemo() }
+        _uiState.update {
+            it.copy(
+                totalPage = totalPage,
+                isLoading = memoId.isNotBlank()
+            )
+        }
+
+        if (memoId.isNotBlank()) {
+            viewModelScope.launch { loadTextMemo() }
+        }
     }
 
     fun onAction(action: TextMemoFormAction) {
@@ -79,8 +87,6 @@ class TextMemoFormViewModel @Inject constructor(
     }
 
     private suspend fun loadTextMemo() {
-        if (memoId.isBlank()) return
-
         val result = bookStorageRepository.getTextMemo(
             userId = userId,
             bookId = bookId,
@@ -98,7 +104,8 @@ class TextMemoFormViewModel @Inject constructor(
                 originalTitle = result.title,
                 originalContent = result.content,
                 originalStartPage = result.startPage.toString(),
-                originalEndPage = if (isSamePage) "" else result.endPage.toString()
+                originalEndPage = if (isSamePage) "" else result.endPage.toString(),
+                isLoading = false
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,10 @@
     <string name="canvas_memo_page_list_scroll_single_page">p.%1$d</string>
     <string name="canvas_memo_top_bar_title">캔버스 메모</string>
     <string name="canvas_memo_place_item_message">아이템을 추가할 위치를 터치해주세요.</string>
+    <string name="canvas_memo_exit_confirmation_dialog_title">변경사항이 저장되지 않았어요.</string>
+    <string name="canvas_memo_exit_confirmation_dialog_description">지금 나가면 작성 중인 내용이 모두 사라집니다.</string>
+    <string name="canvas_memo_exit_confirmation_dialog_dismiss_text">나가기</string>
+    <string name="canvas_memo_exit_confirmation_dialog_confirm_text">계속 편집</string>
 
     <!-- Content Description -->
     <string name="content_description_go_back">뒤로 가기</string>
@@ -110,6 +114,7 @@
     <string name="content_description_confirm">확인</string>
     <string name="content_description_add_book_button">책을 검색하거나 입력하여 책을 추가합니다</string>
     <string name="content_description_save_button">저장하기</string>
+    <string name="content_description_caution">경고</string>
 
     <!-- Add Quote -->
     <string name="add_quote_title">인상 깊은 구절 추가</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,8 +99,8 @@
     <string name="canvas_memo_page_list_scroll_single_page">p.%1$d</string>
     <string name="canvas_memo_top_bar_title">캔버스 메모</string>
     <string name="canvas_memo_place_item_message">아이템을 추가할 위치를 터치해주세요.</string>
-    <string name="canvas_memo_exit_confirmation_dialog_title">변경사항이 저장되지 않았어요.</string>
-    <string name="canvas_memo_exit_confirmation_dialog_description">지금 나가면 작성 중인 내용이 모두 사라집니다.</string>
+    <string name="canvas_memo_exit_confirmation_dialog_title">아직 저장되지 않은 내용이 있어요.</string>
+    <string name="canvas_memo_exit_confirmation_dialog_description">나가면 작성 중인 내용이 사라져요.</string>
     <string name="canvas_memo_exit_confirmation_dialog_dismiss_text">나가기</string>
     <string name="canvas_memo_exit_confirmation_dialog_confirm_text">계속 편집</string>
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- #115 
- #117

## 📝작업 내용
- 데이터 편집 화면에서 이전 상태와 비교하여 나가기 확인 다이얼로그 표시
  - [x] 이전의 상태와 현재 작업중인 상태 전후를 비교하여 뒤로 가기 동작 시 나가기 확인 다이얼로그 표시 
  - 등장인물/인상깊은 구절/텍스트&캔버스 메모 입력 폼 화면, 켄버스 메모 관계도 화면에 적용했습니다.
  - 이미 저장한 데이터를 가져올 경우 `original~` 속성에 해당 값을 보관, 현재 조작 중인 속성과 같은지 비교했습니다.
- 데이터 로딩 시 `CircularProgressIndicator` 표시, 로딩이 끝나면 알맞는 UI와 데이터 표시
   - [x] `characterId`, `quoteId`, `memoId`가 있으면 `isLoading` 속성을 `true`로, 로딩 완료 시 `false`로 설정
   - 등장인물/인상깊은 구절/텍스트&캔버스 메모 입력 폼 화면, 켄버스 메모 관계도 화면에 적용했습니다.
   -  데이터 수정 화면 진입 시, 잠깐 빈 UI를 보여주다가 데이터가 입력되는 부자연스러운 현상을 수정했습니다.

## 📢특이사항

이전 PR이 머지되면 diff는 500줄 가량으로 줄을 것이고,
이번 항목은 같은 작업을 반복한 것이라 하단 테스트 영상과 함께 편하게 확인해주셔도 좋을 것 같습니다.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/4dee33e4-bece-4ee1-917b-8423c093d10c" />

## 🖼️스크린샷

- 기존 상태와 데이터가 동일한 경우 바로 뒤로 가기 동작이 수행되고,
- 그렇지 않은 경우 다이얼로그가 표시되는 것을 각 화면마다 잘 동작하는지 확인한 테스트 영상입니다.

https://github.com/user-attachments/assets/a3d03167-5f26-45a5-9360-f82d49b30ad3

- 데이터 로딩 시 UI 대응 테스트 영상입니다.

https://github.com/user-attachments/assets/2b0b635f-789f-40ed-9048-5db7a7d3c386
