### PR TITLE
노드추가 시 스낵바 , 노드 생성 위치 적용 

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
@@ -77,5 +77,6 @@ sealed interface CanvasMemoAction {
 
     data class PrepareNodePlacement(val character: CharacterUiModel) : CanvasMemoAction
     data class AddNodeAtPosition(val positionOnScreen: Offset) : CanvasMemoAction
+    data class UpdateNodeItemSize(val size: IntSize) : CanvasMemoAction
 
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -1,6 +1,5 @@
 package com.boostcamp.and03.ui.screen.canvasmemo
 
-import android.R.attr.onClick
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -577,6 +576,23 @@ private fun CanvasMemoScreen(
                         )
                     }
                 }
+                if (uiState.nodeToPlace != null && uiState.nodeItemSizePx == null) {
+                    Box(
+                        modifier = Modifier.alpha(0f)
+                    ) {
+                        NodeItem(
+                            title = uiState.nodeToPlace.name,
+                            content = uiState.nodeToPlace.description,
+                            isHighlighted = false,
+                            modifier = Modifier.onGloballyPositioned { coords ->
+                                onAction(
+                                    CanvasMemoAction.UpdateNodeItemSize(coords.size)
+                                )
+                            }
+                        )
+                    }
+                }
+
             }
         }
     }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -202,6 +202,27 @@ private fun CanvasMemoScreen(
                         }
                     )
                 }
+                uiState.nodeToPlace != null -> {
+                    AlertMessageCard(
+                        message = stringResource(R.string.canvas_memo_place_node_message),
+                        actions = listOf(
+                            AlertAction(
+                                text = stringResource(R.string.common_cancel),
+                                onClick = { onAction(CanvasMemoAction.CancelPlaceItem) }
+                            )
+                        ),
+                        modifier = Modifier
+                            .padding(
+                                vertical = And03Padding.PADDING_L,
+                                horizontal = And03Padding.PADDING_XL
+                            )
+                            .windowInsetsPadding(
+                                WindowInsets.safeDrawing.only(
+                                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+                                )
+                            )
+                    )
+                }
 
                 uiState.quoteToPlace != null -> {
                     AlertMessageCard(

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
@@ -54,6 +54,7 @@ data class CanvasMemoUiState(
     val quoteToPlace: QuoteUiModel? = null,
     val quoteItemSizePx: IntSize? = null,
     val nodeToPlace: CharacterUiModel? = null,
+    val nodeItemSizePx: IntSize? = null,
 
     val hasUnsavedChanges: Boolean = false
 ) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
@@ -185,6 +185,10 @@ class CanvasMemoViewModel @Inject constructor(
             is CanvasMemoAction.AddNodeAtPosition ->
                 handleAddNodeAtPosition(action.positionOnScreen)
 
+            is CanvasMemoAction.UpdateNodeItemSize -> {
+                _uiState.update { it.copy(nodeItemSizePx = action.size) }
+            }
+
 
 
 
@@ -879,34 +883,42 @@ class CanvasMemoViewModel @Inject constructor(
             )
         }
     }
-    private fun handleAddNodeAtPosition(positionOnScreen: Offset) {
+    private fun handleAddNodeAtPosition(tapPositionOnScreen: Offset) {
         val character = _uiState.value.nodeToPlace ?: return
+        val size = _uiState.value.nodeItemSizePx ?: return
+
+        val centerOffset = Offset(
+            size.width / 2f,
+            size.height / 2f
+        )
 
         val zoomScale = _uiState.value.zoomScale
         val canvasViewOffset = _uiState.value.canvasViewOffset
 
         val canvasPosition = Offset(
-            x = (positionOnScreen.x - canvasViewOffset.x) / zoomScale,
-            y = (positionOnScreen.y - canvasViewOffset.y) / zoomScale
+            x = (tapPositionOnScreen.x - canvasViewOffset.x) / zoomScale - centerOffset.x,
+            y = (tapPositionOnScreen.y - canvasViewOffset.y) / zoomScale - centerOffset.y
         )
 
         val newNode = MemoNode.CharacterNode(
             id = UUID.randomUUID().toString(),
             name = character.name,
             description = character.description,
-            imageUrl = "",
-            offset = canvasPosition
+            offset = canvasPosition,
+            imageUrl = ""
         )
 
         _uiState.update {
             it.copy(
                 nodes = it.nodes + (newNode.id to newNode.toUiModel()),
                 nodeToPlace = null,
+                nodeItemSizePx = null,
                 isBottomBarVisible = true,
                 hasUnsavedChanges = true
             )
         }
     }
+
 
 
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
@@ -71,15 +71,7 @@ fun NodeItem(
     ) {
         DropdownMenuContainer(
             modifier = Modifier.align(Alignment.TopEnd),
-            trigger = { onClick ->
-                IconButton(onClick = onClick) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.ic_more_vert_filled),
-                        contentDescription = stringResource(R.string.content_description_more_button),
-                        modifier = Modifier.size(NodeItemValues.moreIconSize)
-                    )
-                }
-            },
+            trigger = {},
             menuContent = { closeMenu ->
                 DropdownMenuItem(
                     text = { Text(stringResource(R.string.more_vert_edit)) },

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
@@ -69,25 +69,7 @@ fun NodeItem(
                 And03Theme.shapes.defaultCorner
             )
     ) {
-        DropdownMenuContainer(
-            modifier = Modifier.align(Alignment.TopEnd),
-            trigger = {},
-            menuContent = { closeMenu ->
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.more_vert_edit)) },
-                    onClick = {
-                        closeMenu()
-                    }
-                )
 
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.more_vert_delete)) },
-                    onClick = {
-                        closeMenu()
-                    }
-                )
-            }
-        )
 
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
@@ -98,7 +98,9 @@ fun NodeItem(
         )
 
         Column(
-            modifier = Modifier.fillMaxWidth().padding(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
                     top = And03Padding.PADDING_L,
                     start = And03Padding.PADDING_M,
                     end = And03Padding.PADDING_M,

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/NodeItem.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -18,6 +21,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.boostcamp.and03.R
@@ -28,8 +32,15 @@ import com.boostcamp.and03.ui.theme.And03Spacing
 import com.boostcamp.and03.ui.theme.And03Theme
 
 private object NodeItemValues {
+    val width = 180.dp
+    val height = 240.dp
+
     val borderWidth = 2.dp
     val moreIconSize = 20.dp
+    val iconAreaHeight = 48.dp
+
+    const val TITLE_MAX_LINES = 1
+    const val CONTENT_MAX_LINES = 6
 }
 
 @Composable
@@ -47,6 +58,7 @@ fun NodeItem(
 
     Box(
         modifier = modifier
+            .size(NodeItemValues.width, NodeItemValues.height)
             .background(
                 And03Theme.colors.surface,
                 And03Theme.shapes.defaultCorner
@@ -86,32 +98,52 @@ fun NodeItem(
         )
 
         Column(
-            modifier = Modifier.padding(And03Padding.PADDING_M),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(And03Spacing.SPACE_S)
+            modifier = Modifier.fillMaxWidth().padding(
+                    top = And03Padding.PADDING_L,
+                    start = And03Padding.PADDING_M,
+                    end = And03Padding.PADDING_M,
+                    bottom = And03Padding.PADDING_M
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            IconBadge(
-                iconResId = R.drawable.ic_person_filled,
-                iconColor = And03Theme.colors.primary,
-                contentDescription = stringResource(R.string.content_description_node_item_icon)
-            )
+            Box(
+                modifier = Modifier
+                    .height(NodeItemValues.iconAreaHeight),
+                contentAlignment = Alignment.Center
+            ) {
+                IconBadge(
+                    iconResId = R.drawable.ic_person_filled,
+                    iconColor = And03Theme.colors.primary,
+                    contentDescription = stringResource(R.string.content_description_node_item_icon)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(And03Spacing.SPACE_S))
 
             Text(
                 text = title,
-                style = And03Theme.typography.titleMedium
+                style = And03Theme.typography.titleMedium,
+                maxLines = NodeItemValues.TITLE_MAX_LINES,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
             )
 
+            Spacer(modifier = Modifier.height(And03Spacing.SPACE_S))
+
             Text(
+                modifier = Modifier.weight(1f),
                 text = content,
                 style = And03Theme.typography.bodyMedium,
                 color = And03Theme.colors.onSurfaceVariant,
+                maxLines = NodeItemValues.CONTENT_MAX_LINES,
+                overflow = TextOverflow.Ellipsis,
                 textAlign = TextAlign.Center
             )
         }
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun NodeItemPreview() {
     Column(
@@ -120,22 +152,17 @@ private fun NodeItemPreview() {
     ) {
         NodeItem(
             title = "노드 제목",
-            content = """
-                일반적인 노드의 내용입니다.
-                연속적으로
-                줄바꿈을
-                해봅시다.
-                어떤가요?
-                잘......      나오나요?
-            """.trimIndent(),
+            content = "짧은 내용",
             isHighlighted = false
         )
 
         NodeItem(
-            title = "선택된 노드 제목",
+            title = "노드 제목",
             content = """
-                선택된 노드의 내용입니다.
-                테두리의 색깔이 primary 색상으로 바뀌었습니다.
+                가나다라가나다라가나다라가나다라가나다라가나다라가
+                나다라가나다라가나다라가나다라가나
+                다라가나다라가나다라가나다라가나다라가
+                나다라가나다라가나다라
             """.trimIndent(),
             isHighlighted = true
         )

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/QuoteItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/QuoteItem.kt
@@ -79,27 +79,7 @@ fun QuoteItem(
                 )
             }
     ) {
-        DropdownMenuContainer(
-            modifier = Modifier.align(Alignment.TopEnd),
-            trigger = {},
-            menuContent = { closeMenu ->
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.more_vert_edit)) },
-                    onClick = {
-                        closeMenu()
-                        // onEditClick()
-                    }
-                )
 
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.more_vert_delete)) },
-                    onClick = {
-                        closeMenu()
-                        // onDeleteClick()
-                    }
-                )
-            }
-        )
 
         Row(
             modifier = Modifier.padding(And03Spacing.SPACE_L),

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/QuoteItem.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/component/QuoteItem.kt
@@ -81,15 +81,7 @@ fun QuoteItem(
     ) {
         DropdownMenuContainer(
             modifier = Modifier.align(Alignment.TopEnd),
-            trigger = { onMenuClick ->
-                IconButton(onClick = onMenuClick) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.ic_more_vert_filled),
-                        contentDescription = stringResource(R.string.content_description_more_button),
-                        modifier = Modifier.size(QuoteItemValues.MORE_ICON_SIZE)
-                    )
-                }
-            },
+            trigger = {},
             menuContent = { closeMenu ->
                 DropdownMenuItem(
                     text = { Text(stringResource(R.string.more_vert_edit)) },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,8 @@
     <string name="character_form_enter_role_placeholder">등장인물의 역할을 입력하세요</string>
     <string name="character_form_description">설명</string>
     <string name="character_form_enter_description_placeholder">등장인물을 설명해주세요</string>
+    <string name="canvas_memo_place_node_message">노드를 추가할 위치를 선택해주세요.</string>
+
 
     <!-- InfoSection -->
     <string name="info_section_character_title">등장인물을 새로 추가해보세요.</string>


### PR DESCRIPTION
## #️⃣연관된 이슈
- #이슈번호1: {이슈에 대한 간략한 설명}
- #이슈번호2: {이슈에 대한 간략한 설명}

## 📝작업 내용
> 노드 생성 시 터치한 화면 기준+ 노드 중심으로 설정하여 생성
> 노드 생성 시 스낵바 알림 추가 
> 노드 크기 고정으로 설정 
## 🤔시행착오 및 고민
> 시행착오의 배경과 과정, 결과를 설명해주세요
> 고민한 부분이 있다면 여기에 언급해 주세요

## 💬리뷰 요구사항(선택)
 > 추가했을떄 노드+구절의 크기가 너무큼 (전체 화면에 비해) 
 -> 생각한 해결 방법 
 ----> 캔버스의 크기(전체 도화지 크기) 키우거나  또는 노드의 크기 + 구절의 크기를 줄여야 된다고 생각이 드는데 어떻게 생각하시나요? 
## 🖼️스크린샷 (선택)

[hello.webm](https://github.com/user-attachments/assets/511c4c27-a1c5-43a4-8196-7b9ee9948938)
