### PR TITLE
캔버스 노드 추가 다이얼로그 연동 

### DIFF
--- a/app/src/main/java/com/boostcamp/and03/data/mapper/CharacterRequestMapper.kt
+++ b/app/src/main/java/com/boostcamp/and03/data/mapper/CharacterRequestMapper.kt
@@ -15,11 +15,9 @@ fun CharacterRequest.toEntity(
         "description" to description,
         "profileType" to profileType.name
     )
-
+ // 이미지가 없으면 필드없이 보내기.
     if (profileType == ProfileType.IMAGE && imageUrl != null) {
         map["imageUrl"] = imageUrl
-    } else {
-        map["imageUrl"] = FieldValue.delete()
     }
 
     if (profileType == ProfileType.COLOR && profileColor != null) {

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoAction.kt
@@ -94,4 +94,11 @@ sealed interface CanvasMemoAction {
     data class DeleteSelectedItems(val itemIds: ImmutableList<String>) : CanvasMemoAction
 
     data object CancelRelationStep : CanvasMemoAction
+
+    data object OpenAddCharacterDialog : CanvasMemoAction
+
+    data object SaveCharacter : CanvasMemoAction
+
+
+
 }

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoScreen.kt
@@ -54,6 +54,7 @@ import com.boostcamp.and03.R
 import com.boostcamp.and03.ui.component.And03AppBar
 import com.boostcamp.and03.ui.component.And03Dialog
 import com.boostcamp.and03.ui.component.DialogDismissAction
+import com.boostcamp.and03.ui.screen.canvasmemo.component.AddCharacterDialog
 import com.boostcamp.and03.ui.screen.canvasmemo.component.AddNodeBottomSheet
 import com.boostcamp.and03.ui.screen.canvasmemo.component.AddQuoteBottomSheet
 import com.boostcamp.and03.ui.screen.canvasmemo.component.AddQuoteDialog
@@ -67,14 +68,11 @@ import com.boostcamp.and03.ui.screen.canvasmemo.component.RelationEditorDialog
 import com.boostcamp.and03.ui.screen.canvasmemo.component.ToolAction
 import com.boostcamp.and03.ui.screen.canvasmemo.component.ToolExpandableButton
 import com.boostcamp.and03.ui.screen.canvasmemo.component.bottombar.MainBottomBar
-import com.boostcamp.and03.ui.screen.canvasmemo.component.bottombar.MainBottomBarItem
 import com.boostcamp.and03.ui.screen.canvasmemo.component.bottombar.MainBottomBarType
-import com.boostcamp.and03.ui.screen.canvasmemo.model.EdgeUiModel
 import com.boostcamp.and03.ui.screen.canvasmemo.model.MemoNodeUiModel
 import com.boostcamp.and03.ui.screen.canvasmemo.model.RelationAddStep
 import com.boostcamp.and03.ui.theme.And03Padding
 import com.boostcamp.and03.ui.theme.And03Theme
-import com.boostcamp.and03.ui.theme.CanvasMemoColors
 import com.boostcamp.and03.ui.util.collectWithLifecycle
 import kotlinx.coroutines.launch
 
@@ -445,6 +443,27 @@ private fun CanvasMemoScreen(
                         totalPage = uiState.totalPage
                     )
                 }
+                if (uiState.isAddCharacterDialogVisible) {
+                    AddCharacterDialog(
+                        nameState = uiState.characterNameState,
+                        descState = uiState.characterDescState,
+                        profileType = uiState.characterProfileType,
+                        imageUrl = uiState.characterImageUrl,
+                        iconColor = uiState.characterIconColor,
+                        enabled = uiState.isCharacterSaveable && !uiState.isSaving,
+                        onDismiss = {
+                            onAction(CanvasMemoAction.CloseAddCharacterDialog)
+                        },
+                        onConfirm = {
+                            onAction(CanvasMemoAction.SaveCharacter)
+                        },
+                        onClickAddImage = { // 이미지 추가 처리 필요
+                        }
+                    )
+                }
+
+
+
 
                 if (uiState.isExitConfirmationDialogVisible && uiState.hasUnsavedChanges) {
                     And03Dialog(
@@ -489,7 +508,12 @@ private fun CanvasMemoScreen(
                                     infoTitle = stringResource(R.string.add_node_bottom_sheet_info_title),
                                     infoDescription = stringResource(R.string.add_node_bottom_sheet_info_description),
                                     onSearch = { },
-                                    onNewCharacterClick = { },
+                                    onNewCharacterClick = {
+                                        scope.launch {
+                                            onAction(CanvasMemoAction.OpenAddCharacterDialog)
+                                            sheetState.hide()
+                                        }
+                                    },
                                     onAddClick = { character ->
                                         if (character == null) return@AddNodeBottomSheet
 

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoUiState.kt
@@ -2,7 +2,9 @@ package com.boostcamp.and03.ui.screen.canvasmemo
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.IntSize
+import com.boostcamp.and03.data.model.request.ProfileType
 import com.boostcamp.and03.ui.screen.bookdetail.model.CharacterUiModel
 import com.boostcamp.and03.ui.screen.bookdetail.model.QuoteUiModel
 import com.boostcamp.and03.ui.screen.canvasmemo.component.bottombar.MainBottomBarType
@@ -36,6 +38,11 @@ data class CanvasMemoUiState(
     val isQuoteDialogVisible: Boolean = false,
     val isExitConfirmationDialogVisible: Boolean = false,
     val isSureDeleteDialogVisible: Boolean = false,
+
+    val characterProfileType: ProfileType = ProfileType.COLOR,
+    val characterImageUrl: String? = null,
+    val characterIconColor: Color = Color(0xFF1E88E5), // 임시 컬러 적용
+    val isCharacterSaveable: Boolean = true,
 
     val characterNameState: TextFieldState = TextFieldState(),
     val characterDescState: TextFieldState = TextFieldState(),

--- a/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
+++ b/app/src/main/java/com/boostcamp/and03/ui/screen/canvasmemo/CanvasMemoViewModel.kt
@@ -1019,16 +1019,17 @@ class CanvasMemoViewModel @Inject constructor(
                 )
             )
 
-            // 저장 후 다이얼로그 닫기
             _uiState.update {
                 it.copy(
                     isAddCharacterDialogVisible = false,
+                    bottomSheetType = CanvasMemoBottomSheetType.AddCharacter,
                     characterNameState = TextFieldState(),
                     characterDescState = TextFieldState()
                 )
             }
         }
     }
+
 
 
 


### PR DESCRIPTION
## 📝작업 내용
> 캔버스 화면에서도 등장인물을 생성할 수 있도록 구현했습니다. 


### 🟩TODO
- 아이콘을 선택했을 경우 갤러리에서 이미지를 불러오거나 사진을 직접 촬영할 수 있는 기능은 추가하지 않았습니다.
- 이미지를 추가하지 않았을때 아이콘 컬러가 임시(랜덤)으로 바뀌는 로직을 적용하지 못했습니다. 
   -> 바텀시트에서 랜덤으로 컬러가 바뀌는 처리가 되어 있긴한데 이부분 애기해보고 맞춰봐야 할 것 같습니다. 
- 구절 추가 하고 나면 바텀시트로 돌아가는게 좋을까요 아니면  

## 💬리뷰 요구사항(선택)
> 현재 노드 추가 다이얼로그에서 생성을 성공하면 (배경은 캔버스 화면) 다시 바텀시트를 띄워주는데 괜찮은가요? 아마 구절추가 로직과 통일 해야 할 것 같은데.  
제가 생각했던 로직은 다음과 같습니다. 뭐가 괜찮을까요? 아니면 다른 방식이 있을지 
1. 생성 다이얼로그(뒷 배경은 캔버스) ->생성 성공 -> 바텀시트 다시 띄워주기 (현재방식입니다) 
2. 생성 다이얼로그(뒷 배경은 바텀시트) ->생성 성공-> 그대로 바텀시트
3. 생성 다이얼로그(뒷 배경은 캔버스) -> 생성 성공 -> 캔버스 스크린
4. 생성 다이얼로그(뒷 배경은 바텀시트) -> 생성 성공 -> 캔버스 스크린

## 🖼️스크린샷 (선택)
[gamza.webm](https://github.com/user-attachments/assets/2d10e34c-f082-4e7a-b1df-41ee697c7d6b)

